### PR TITLE
docs(claude): GitHub Issues = unique source de vérité (CR/KF/bugs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ Cette règle s'applique à :
 
 **Règle de traçage des CR, KF et bug reports** :
 
-Toute nouvelle découverte d'un **CR (Change Request)**, d'une **KF (Known Failure)** ou d'un **bug report** DOIT être créée comme GitHub Issue sur [guycorbaz/kesh/issues](https://github.com/guycorbaz/kesh/issues) en utilisant le template approprié dans `.github/ISSUE_TEMPLATE/`.
+**GitHub Issues est l'unique source de vérité.** Toute nouvelle découverte d'un **CR (Change Request)**, d'une **KF (Known Failure)** ou d'un **bug report** DOIT être créée comme GitHub Issue sur [guycorbaz/kesh/issues](https://github.com/guycorbaz/kesh/issues) en utilisant le template approprié dans `.github/ISSUE_TEMPLATE/`.
+
+**Pas de tracking local en parallèle** — aucun fichier dans le repo (Markdown, YAML, tableau de story) ne doit maintenir sa propre liste de KF/CR/bugs. Pas de double-tracking, pas de sync bidirectionnelle, pas de dérive de source de vérité.
 
 | Type | Template | Labels appliqués par le template |
 |------|----------|----------------------------------|
@@ -95,18 +97,12 @@ Toute nouvelle découverte d'un **CR (Change Request)**, d'une **KF (Known Failu
 | KF | `known_failure.yml` | `known-failure`, `triage` (+ `technical-debt` à ajouter manuellement si dette persistante) |
 | CR / feature request | `feature_request.yml` | `enhancement`, `triage` |
 
-### Double-tracking KF (GitHub + offline)
-
-Les KF sont suivies aux deux endroits :
-- **GitHub Issues** — source online pour triage, cross-référence dans les commits, discussion asynchrone.
-- **`docs/known-failures.md`** — source offline / dans Git, persiste même sans connexion GitHub. Chaque entrée KF-NNN référence son issue GitHub (ex. `**GitHub** : [#2](https://github.com/guycorbaz/kesh/issues/2)`).
-
-Sync bidirectionnelle manuelle : si on modifie l'un, on modifie l'autre. Les CR et bug reports n'ont que GitHub comme source (pas de fichier offline).
+Titre homogène pour les KF : `[KF-NNN] description` — facilite la recherche visuelle dans la liste d'issues.
 
 ### Quand créer une issue
 
-- **Bug report** : dès qu'un comportement incorrect est reproduit, **hors du flux normal de dev d'une story en cours**. Si le bug est découvert pendant l'implémentation d'une story liée, le corriger directement dans la story et le documenter dans le Change Log.
-- **KF** : dès qu'un test cassé ou un comportement défaillant est détecté **hors scope du travail courant**. Cf. convention `docs/known-failures.md`.
+- **Bug report** : dès qu'un comportement incorrect est reproduit, **hors du flux normal de dev d'une story en cours**. Si le bug est découvert pendant l'implémentation d'une story liée, le corriger directement dans la story et le documenter dans le Change Log de la story.
+- **KF** : dès qu'un test cassé ou un comportement défaillant est détecté **hors scope du travail courant**.
 - **CR** : **avant** tout changement de scope qui modifie le PRD ou les AC d'une story déjà validée (`done` ou en `review`). Ne pas faire de modification silencieuse du scope.
 
 ### Commits qui adressent une issue
@@ -117,8 +113,12 @@ Chaque commit qui adresse partiellement ou totalement une issue doit mentionner 
 
 ### Legacy
 
-- Les **CR antérieurs à 2026-04-16** dans `docs/change_request.md` restent historiques — ne sont pas migrés rétroactivement.
-- Les **KF antérieures** (KF-001 à KF-006 au 2026-04-16) ont été migrées manuellement lors de l'instauration de cette règle.
+Deux fichiers dans `docs/` sont **archivés et ne doivent plus être mis à jour** — ils ne servent que de trace historique :
+
+- `docs/change_request.md` — archivé depuis 2026-04-16, 8 CR migrés sur GitHub.
+- `docs/known-failures.md` — archivé depuis 2026-04-18, 7 KF migrées sur GitHub (KF-001 à KF-007).
+
+Toute nouvelle KF/CR/bug → GitHub uniquement. Ne **pas** rouvrir ces fichiers pour y ajouter des entrées.
 
 ## Règle de commit et push
 

--- a/docs/known-failures.md
+++ b/docs/known-failures.md
@@ -1,14 +1,13 @@
 # Known Failures (KF)
 
-Registre des tests/comportements **constatés cassés mais hors scope** du travail en cours, à ne pas oublier de corriger.
+> **📌 Archivé 2026-04-18** : ce fichier est **figé**. Les KF sont désormais suivies **uniquement** sur [GitHub Issues](https://github.com/guycorbaz/kesh/issues?q=label%3Aknown-failure) conformément à la règle `CLAUDE.md` « Issue Tracking Rule » (GitHub = unique source de vérité). Tout nouvelle KF doit être créée via le template `known_failure.yml` avec un titre `[KF-NNN] ...`.
+>
+> Les 7 KF historiques ci-dessous (KF-001 à KF-007) ont été migrées sur GitHub. Ce fichier reste uniquement la trace historique de la convention pré-2026-04-18. **Ne pas y ajouter de nouvelle entrée** — toute mise à jour d'une KF existante se fait sur l'issue GitHub correspondante.
 
-## Convention
+## Convention historique (pré-archivage)
 
-- **Une entrée par défaillance** identifiée par un ID `KF-NNN`.
+- Une entrée par défaillance identifiée par un ID `KF-NNN`.
 - Format : symptôme reproductible, root cause hypothétique, story d'origine, story de remédiation prévue, status (`open` / `closed`).
-- Une KF résolue passe à `status: closed` + lien vers le commit fix.
-- Pattern process : tout commit qui constate un échec hors scope doit mentionner la KF dans son message.
-- **Double tracking GitHub Issues** depuis 2026-04-16 — chaque KF a une issue sur [guycorbaz/kesh](https://github.com/guycorbaz/kesh/issues?q=label%3Aknown-failure) avec les labels `known-failure` + éventuellement `technical-debt` + `triage`. Ce fichier reste la source de vérité offline / dans Git ; GitHub est la source online pour triage.
 
 ---
 


### PR DESCRIPTION
## Summary

Simplifie la règle « Issue Tracking Rule » de `CLAUDE.md` : **GitHub Issues = unique source de vérité** pour les CR, KF et bug reports. Plus de double-tracking offline.

## Changements

**`CLAUDE.md`**
- Retrait de la section « Double-tracking KF (GitHub + offline) ».
- Ajout d'une règle explicite « Pas de tracking local en parallèle » (pas de fichier Markdown, YAML ou tableau de story qui maintient sa propre liste).
- Ajout de la convention titre `[KF-NNN] ...` pour les issues GitHub (facilite la recherche visuelle).
- Section « Legacy » mise à jour : `docs/known-failures.md` et `docs/change_request.md` sont figés, ne plus mettre à jour.

**`docs/known-failures.md`**
- En-tête « Archivé 2026-04-18 » aligné sur le format de `docs/change_request.md` (archivé 2026-04-16).
- Fichier conservé pour trace historique — **pas** supprimé. Les 7 KF (KF-001 à KF-007) restent visibles.
- Toute future mise à jour d'une KF existante se fait sur son issue GitHub.

## Rationale

Le double-tracking a servi de filet lors de la migration initiale (2026-04-16). Depuis :
- Les 7 KF sont toutes sur GitHub avec titres homogènes (`[KF-NNN] ...`).
- Le fichier offline dérivait déjà : sync manuelle bidirectionnelle = source de dette et d'incohérence.
- Guy a arbitré aujourd'hui (2026-04-18) en faveur d'une source unique.

## Test plan

- [ ] CI : 4 jobs verts (pas de changement code, juste de la doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)