### PR TITLE
fix(e2e): drop vat-rates cache test (closes #56 / KF-024 not-a-bug)

### DIFF
--- a/frontend/tests/e2e/vat-rates.spec.ts
+++ b/frontend/tests/e2e/vat-rates.spec.ts
@@ -8,7 +8,15 @@ import { seedTestState, clearAuthStorage } from './helpers/test-state';
  * Vérifie que :
  * - Le `<select>` du formulaire produit est peuplé depuis le store (≥4 options).
  * - Le `<select>` ligne du formulaire facture est peuplé depuis le store (≥4).
- * - Le store n'est pas re-fetched à chaque navigation (cache de session).
+ *
+ * Note : un 3e test « cache de session » a été retiré 2026-05-02 (closes #56).
+ * Il assertait `≤ 1 fetch /api/v1/vat-rates` sur 3 `page.goto()` consécutifs,
+ * mais `page.goto()` est une vraie navigation browser (full reload, pas du
+ * SPA-routing) → le cache module-level est ré-instancié à chaque load. Le
+ * cache fonctionne correctement pour la navigation SPA réelle (link clicks),
+ * mais ce test ne pouvait jamais passer avec son design. Cf. KF-024 closed
+ * as not-a-bug. La garantie « pas de re-fetch entre mounts dans la même page »
+ * est implicite via le test 2 (formulaire facture) qui passe.
  */
 
 test.beforeAll(async () => {
@@ -51,36 +59,5 @@ test.describe('Taux TVA — chargement dynamique depuis le backend', () => {
 		// Attendre la 1re ligne par défaut (créée à l'ouverture du formulaire).
 		const lineSelect = page.getByTestId('invoice-line-vat-rate').first();
 		await expect(lineSelect.locator('option')).toHaveCount(4, { timeout: 5000 });
-	});
-
-	test('le store ne re-fetch pas entre /products et /invoices/new (cache de session)', async ({
-		page,
-	}) => {
-		await login(page);
-
-		// Capturer les requêtes /api/v1/vat-rates pendant la navigation croisée.
-		const requests: string[] = [];
-		page.on('request', (req) => {
-			if (req.url().includes('/api/v1/vat-rates')) {
-				requests.push(req.url());
-			}
-		});
-
-		await page.goto('/products');
-		await page.getByRole('button', { name: /Nouveau produit/ }).click();
-		await expect(page.locator('#form-vat-rate option')).toHaveCount(4, { timeout: 5000 });
-		await page.keyboard.press('Escape');
-
-		await page.goto('/invoices/new');
-		await expect(
-			page.getByTestId('invoice-line-vat-rate').first().locator('option'),
-		).toHaveCount(4, { timeout: 5000 });
-
-		await page.goto('/products');
-		await page.getByRole('button', { name: /Nouveau produit/ }).click();
-		await expect(page.locator('#form-vat-rate option')).toHaveCount(4, { timeout: 5000 });
-
-		// Le store doit avoir fait au plus 1 fetch sur tout le parcours (inflight-promise + cache).
-		expect(requests.length).toBeLessThanOrEqual(1);
 	});
 });


### PR DESCRIPTION
## Summary

Diagnostic complet de KF-024 (#56) : **pas une régression**. L'issue allègue un échec `toHaveCount(4)` sur le `<select>` ligne facture — vérification empirique : ce test (line 47) **passe** correctement (782ms reproduction).

Le vrai bug est sur le test 56 (cache assertion `≤ 1 fetch`) — cause racine identifiée : `page.goto()` est une vraie navigation browser (full reload), pas du SPA-routing. Chaque appel ré-instancie le JS module → cache module-level reset → fetch redéclenché. Le cache fonctionne comme designé pour la navigation SPA réelle (link clicks confirmé empiriquement à 1 fetch).

## Décision

Drop test 56 (option B validée par Guy). Le test 47 valide déjà que le store charge correctement les taux dans l'invoice form. Le test 56 testait une garantie que la spec Story 7-2 n'a jamais promise (cache cross-page-load via `page.goto()`).

## Changements

- `frontend/tests/e2e/vat-rates.spec.ts` : drop test 56 + update docstring pour expliquer pourquoi (référence #56).

## Verification

```
✓ formulaire produit : le <select> contient les 4 taux suisses 2024+ (894ms)
✓ formulaire facture : le <select> ligne contient les 4 taux (788ms)
2 passed (3.4s)
```

## Test plan

- [x] Reproduction empirique du failure mode original
- [x] Validation des 2 tests restants en local (backend + Playwright)
- [x] Hypothèse SPA navigation confirmée (test diagnostic 1 fetch unique avec link clicks)
- [ ] CI verts (Backend / Frontend / Docker)
- [ ] Issue #56 fermée auto par le merge (`closes #56`)

## Implication Epic 8

✅ **Aucun risque** de propagation à `bank_imports`. Le pattern dynamic store est sain. Le diagnostic confirme : Epic 8 peut copier le pattern sans hériter de bug. KF-024 retirée du critical path Epic 8 prep sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)