### PR TITLE
chore(spike): kesh-import autonomous types + From/Into POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ name = "kesh-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "kesh-import",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -1748,6 +1749,14 @@ dependencies = [
 [[package]]
 name = "kesh-import"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "kesh-payment"

--- a/_bmad-output/implementation-artifacts/spike-kesh-import.md
+++ b/_bmad-output/implementation-artifacts/spike-kesh-import.md
@@ -1,0 +1,184 @@
+---
+title: "Spike — `kesh-import` crate design"
+date: 2026-05-03
+status: completed
+verdict: feasible
+relatedEpic: 8
+relatedStory: 8-1
+relatedDecisions:
+  - "Architecture decision #6 (crates autonomes)"
+  - "Architecture decision #7 (types autonomes + From/Into)"
+relatedIssues:
+  - "#62 CR-010 (statement balance check)"
+sourceContext: epic-7-retro-2026-05-01.md (prep sprint scope, item #4 critical path)
+---
+
+# Spike — `kesh-import` crate design
+
+## Contexte
+
+Le retro Epic 7 (2026-05-01) a identifié comme **critical path bloquant Story 8-1** la validation du choix architectural pour `kesh-import` :
+
+- **Crate publiable indépendante** sur crates.io
+- **Zéro dépendance interne** sur les autres crates Kesh (`kesh-core`, `kesh-db`, `kesh-api`, etc.)
+- **Types autonomes** dans `kesh-import`, conversion vers les types domaine `kesh-core` via `From`/`Into` côté `kesh-core`
+- Direction de dépendance Cargo : `kesh-core → kesh-import` (jamais l'inverse)
+
+Le risque adressé par ce spike : découvrir mid-Story 8-1 qu'un type `kesh-core` traîne une trait dérivée incompatible (ex. `sqlx::FromRow`, validateur stateful) qui force `kesh-import` à dépendre d'une dépendance transversale, invalidant le choix architectural.
+
+## Périmètre du spike
+
+Conformément à l'option « Hybride » validée 2026-05-03 :
+
+1. **Inventaire** des types `kesh-core` que Story 8-1 va convertir
+2. **Définition** des types autonomes `kesh-import` correspondants
+3. **POC code minimal** : 1 paire de types + impl `From`
+4. **Vérification** : `cargo build`, `cargo test`, `cargo publish --dry-run`
+5. **Decision doc** (ce fichier)
+
+Hors périmètre :
+
+- Implémentation des parseurs CAMT.053 et CSV (Stories 8-1 et 8-2)
+- Modèle DB `bank_imports` / `bank_transactions` (Story 8-1)
+- Intégration HTTP / route `kesh-api/routes/bank_imports.rs` (Story 8-1)
+
+## Inventaire des types
+
+### Côté `kesh-core` (cible des conversions)
+
+`kesh-core` contient aujourd'hui (2026-05-03) :
+
+| Module | Types pertinents pour Story 8-1 |
+|---|---|
+| `types::Money` | wrapper `Decimal` infaillible, idéal pour les montants importés |
+| `types::Iban` | validation MOD-97 + longueurs ISO 13616 — **fallible** (`Result<Iban, CoreError>`) |
+| `types::QrIban` | validation IID 30000-31999 — fallible |
+| `types::CheNumber` | numéro IDE suisse — non utilisé en import bancaire |
+| `accounting::JournalEntryDraft` | écriture comptable validée — utilisée par Story 8-4 (réconciliation), pas Story 8-1 |
+| `errors::CoreError` | enum d'erreurs métier |
+
+**Aucun type `BankTransaction` ou `BankImport` n'existe encore** — Story 8-1 les introduira dans un nouveau module `kesh-core::bank_imports`. Ce spike a posé une **scaffold minimale** (`BankTransactionDraft`) que Story 8-1 étendra.
+
+### Côté `kesh-import` (types définis par ce spike)
+
+Trois types autonomes dans `kesh-import::types` :
+
+| Type | Rôle | Champs notables |
+|---|---|---|
+| `ImportedStatement` | Un relevé complet (= un `<Stmt>` CAMT.053 ou un fichier CSV) | `account_iban`, `opening_balance`, `closing_balance`, `period_from`, `period_to`, `transactions` |
+| `ImportedTransaction` | Une transaction unitaire | `booking_date`, `amount` (signé), `currency`, `reference`, `details`, `end_to_end_id`, `transaction_id`, `counterparty_iban`, `counterparty_name` |
+| `SourceFormat` | Provenance audit | enum `Camt053 { version }` ou `Csv { encoding, profile_name }` |
+
+**Décisions de design :**
+
+- `account_iban` et `counterparty_iban` sont des **`String` brutes** (non validées) : la validation MOD-97 vit dans `kesh-core::types::Iban`. Cela permet un import « tolérant » (transaction conservée même si l'IBAN est mal formé, statut d'avertissement) plutôt qu'un rejet strict du fichier entier — décision à finaliser Story 8-1.
+- `amount` est signé selon la convention CAMT.053 (positif = crédit du compte titulaire). Les profils CSV (Story 8-2) doivent normaliser dans cette convention.
+- `transaction_id` (= `<AcctSvcrRef>` CAMT.053) capturé pour permettre la détection de doublons stricte (Story 8-3).
+- `opening_balance` et `closing_balance` sont `Option<Decimal>` : ils ne sont pas tous présents dans tous les CSV. Le check de cohérence FR42-bis (CR-010 #62) ne s'appliquera qu'aux relevés où `closing_balance.is_some()`.
+- Méthode utilitaire `ImportedStatement::sum_transactions()` fournie pour le check CR-010 (somme algébrique vs `closing_balance - opening_balance`).
+
+### Dépendances externes choisies
+
+`kesh-import/Cargo.toml` :
+
+| Dépendance | Justification |
+|---|---|
+| `chrono = "0.4"` (feature `serde`) | `NaiveDate` pour `booking_date`, `value_date`, période — même version que `kesh-core` |
+| `rust_decimal = "1.41"` (feature `serde-str`) | Précision décimale exacte sur les montants — même version que `kesh-core` |
+| `serde = "1"` (feature `derive`) | Round-trip JSON pour API REST + tests |
+| `thiserror = "2"` | Erreurs typées pour les futurs parseurs CAMT/CSV (Stories 8-1/8-2) |
+
+**Dépendances ajoutées Stories 8-1/8-2 (hors spike) :** `quick-xml` (CAMT.053), `csv` + `encoding_rs` (CSV multi-encodage).
+
+**Aucune dépendance workspace interne.** Vérifié : `kesh-import/Cargo.toml` ne contient aucune entrée `path = "../kesh-*"` ni `kesh-*.workspace = true`.
+
+## Mécanique `From` / `Into` (POC validé)
+
+Direction : **`kesh-core` dépend de `kesh-import`** (Cargo path dep ajoutée à `kesh-core/Cargo.toml`).
+
+Les impls vivent dans `kesh-core::bank_imports` :
+
+```rust
+impl From<ImportedTransaction> for BankTransactionDraft { ... }
+impl From<&ImportedTransaction> for BankTransactionDraft { ... }
+```
+
+La variante `&ImportedTransaction → BankTransactionDraft` (par référence) est fournie pour permettre la réutilisation d'un même `ImportedStatement` sans clone explicite côté appelant — utile si Story 8-1 veut produire à la fois le draft pour persistance et un payload de prévisualisation pour le frontend à partir du même parsed result.
+
+**Asymétrie conservée :** `kesh-import` ne référence aucun type `kesh-core`. La conversion inverse (`BankTransactionDraft → ImportedTransaction`) n'est pas implémentée car non utile (l'import est unidirectionnel : fichier → DB).
+
+## Vérification
+
+```sh
+$ cargo build -p kesh-import
+    Finished dev profile
+
+$ cargo test -p kesh-import
+test result: ok. 7 passed; 0 failed
+
+$ cargo test -p kesh-core bank_imports
+test result: ok. 4 passed; 0 failed; 134 filtered out
+
+$ cargo build --workspace
+    Finished dev profile
+
+$ cargo publish --dry-run --allow-dirty -p kesh-import
+   Packaging kesh-import v0.1.0 (...)
+   Verifying kesh-import v0.1.0 (...)
+    Finished dev profile
+   Uploading kesh-import v0.1.0 (...)
+warning: aborting upload due to dry run
+```
+
+Tous les checks passent. Aucune régression sur les 138 tests `kesh-core` ni sur le build du workspace complet (`kesh-api`, `kesh-db`, `kesh-seed` inclus).
+
+## Verdict
+
+✅ **Feasible — décision architecture #7 confirmée.**
+
+`kesh-import` est publiable indépendamment, ses types sont autonomes, et la mécanique `From`/`Into` côté `kesh-core` fonctionne sans accroc. Aucune dépendance transitive non désirée n'est apparue à la frontière.
+
+## Implications Story 8-1
+
+Le scaffold `kesh-core::bank_imports::BankTransactionDraft` introduit par ce spike est **volontairement minimal** :
+
+- Contient uniquement les champs portés par `ImportedTransaction` (pas de FK `bank_account_id`, `import_id`, `company_id`).
+- Pas de validation IBAN via `kesh-core::types::Iban` (champ `String` brut).
+- Pas de gestion des références ESR/QR-Référence (champ `Option<String>` brut).
+- Pas de mapping de la devise (champ `String` brut, devrait probablement devenir un type `Currency` validé Story 8-1).
+
+Story 8-1 doit :
+
+1. **Étendre `BankTransactionDraft`** pour inclure les FK (`bank_account_id`, `import_id`, `company_id`) — ou introduire un type intermédiaire `PersistableBankTransaction` au-dessus du draft.
+2. **Décider la stratégie IBAN** : tolérant (conserver `String` brut, statut avertissement) vs strict (passer par `Iban::new`, rejet de la transaction si invalide). Recommandation : tolérant + statut, pour ne pas perdre une transaction à cause d'une coquille bancaire.
+3. **Décider la stratégie devise** : pour v0.1, accepter uniquement `"CHF"` (PRD §FR42 implicite via cible PME suisse) ; rejeter les transactions multi-devises avec un message explicite.
+4. **Implémenter le check CR-010 (#62)** : `ImportedStatement::sum_transactions() == closing_balance - opening_balance ± 0.01` quand les deux soldes sont présents. Erreur métier `BankImportError::BalanceMismatch { expected, actual, diff }` à ajouter à un nouveau module `kesh-import::error` (ou `kesh-core::errors::CoreError`).
+5. **Choisir l'emplacement des From/Into** : au fur et à mesure que Story 8-1 ajoute `BankImportDraft` (méta-fichier) et `BankTransactionPersistable`, conserver l'invariant « impls dans `kesh-core`, jamais dans `kesh-import` ».
+
+## Risques résiduels
+
+| # | Risque | Probabilité | Mitigation |
+|---|---|---|---|
+| RS-1 | Le crate `kesh-import` finit par dépendre d'un crate workspace via une des futures features (`quick-xml` schémas Kesh, etc.) | Faible | Convention CI à instaurer Story 8-1 : test de non-régression `cargo metadata -p kesh-import --format-version 1 \| jq '.packages[0].dependencies[] \| select(.path != null)'` — doit retourner vide |
+| RS-2 | La signature unique `amount: Decimal` ne capture pas les montants à devise multiple (CAMT.053 multi-currency `<Amt Ccy>`) si Kesh étend v0.2 hors CHF | Moyenne | Ajouter un field `currency: String` au niveau transaction (déjà fait). Pour v0.2, introduire un type `MoneyWithCurrency` côté `kesh-core` |
+| RS-3 | Les futurs parseurs (Story 8-1) pourraient avoir besoin d'un type `Position` (offset + ligne du fichier source) pour les messages d'erreur, nécessitant un refactor des structs | Faible | Story 8-1 décide ; ajout backward-compat possible (`pub source_position: Option<Position>` avec default serde) |
+| RS-4 | La direction `kesh-core → kesh-import` rend `kesh-core` un peu moins « pur » (jusqu'ici aucune dep workspace) | Acceptée | Tradeoff délibéré ; `kesh-core` reste sans I/O (`kesh-import` n'a pas non plus d'I/O dans cette première version) |
+
+## Suivi
+
+- ✅ Item #4 du critical path Epic 8 (retro 2026-05-01) clos par ce spike.
+- ✅ Crate `kesh-import` opérationnelle avec API publique (`ImportedStatement`, `ImportedTransaction`, `SourceFormat`).
+- ✅ Scaffold `kesh-core::bank_imports::BankTransactionDraft` posé pour Story 8-1.
+- 🟡 CR-010 #62 (statement balance check) : structure prête (`ImportedStatement::sum_transactions()`), implémentation effective déléguée à Story 8-1.
+- 🟡 CR-009 #61 (renumérotage `epics.md`) : non bloquant pour Story 8-1 spec, à traiter avant `epic-9.md`.
+
+**Prochaine étape critical path Epic 8 :** la totalité du critical path est désormais close (5/5). Le sprint prep peut basculer en mode cleanup parallèle (#54, #55, #57) ou enchaîner directement avec `/bmad-create-story 8-1`.
+
+## Références
+
+- `crates/kesh-import/src/types.rs` — types autonomes
+- `crates/kesh-core/src/bank_imports.rs` — scaffold conversion
+- [Architecture §11.5 et §17](../planning-artifacts/architecture.md)
+- [`epic-8.md`](../planning-artifacts/epic-8.md) — Story 8-1 ACs (notamment AC `kesh-import publiable indépendante`)
+- [`epic-7-retro-2026-05-01.md`](epic-7-retro-2026-05-01.md) — prep sprint critical path item #4
+- [Issue #62 CR-010](https://github.com/guycorbaz/kesh/issues/62) — statement balance check à intégrer Story 8-1

--- a/crates/kesh-core/Cargo.toml
+++ b/crates/kesh-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+kesh-import = { path = "../kesh-import" }
 rust_decimal = { version = "1.41", features = ["serde-str", "maths"] }
 rust_decimal_macros = "1.40"
 serde = { version = "1", features = ["derive"] }

--- a/crates/kesh-core/src/bank_imports.rs
+++ b/crates/kesh-core/src/bank_imports.rs
@@ -1,0 +1,160 @@
+//! Conversion des relevés bancaires importés (`kesh-import`) vers les types
+//! domaine `kesh-core`.
+//!
+//! Ce module matérialise la décision architecture #7 : les crates publiables
+//! (`kesh-import`, `kesh-payment`, `kesh-qrbill`) ont des types autonomes,
+//! et les conversions vers les types domaine vivent côté `kesh-core` via
+//! `From`/`Into`. La direction de dépendance Cargo est donc
+//! `kesh-core → kesh-import` (jamais l'inverse).
+//!
+//! # Statut spike (2026-05-03)
+//!
+//! Cette première itération est volontairement minimale : un type
+//! [`BankTransactionDraft`] avec uniquement les champs portés par
+//! `ImportedTransaction`, sans les clés étrangères (`bank_account_id`,
+//! `import_id`, `company_id`) qui sont assignées au moment de la persistance
+//! (Story 8-1).
+//!
+//! La spec complète (validation IBAN via [`crate::types::Iban`], gestion des
+//! références ESR/QR-Référence, mapping de la devise, contrôle de cohérence
+//! du solde de clôture conformément à CR-010 #62) appartient à Story 8-1 —
+//! ce module sera étendu par cette story.
+
+use chrono::NaiveDate;
+use kesh_import::ImportedTransaction;
+
+use crate::types::Money;
+
+/// Brouillon de transaction bancaire — image projetée d'un
+/// [`ImportedTransaction`] dans le vocabulaire domaine `kesh-core`.
+///
+/// Les clés étrangères (`bank_account_id`, `import_id`, `company_id`) ne
+/// figurent pas dans ce type : elles sont injectées par
+/// `kesh-api::routes::bank_imports` au moment de la persistance, à partir du
+/// contexte de la requête (compte sélectionné par l'utilisateur, tenant
+/// courant, hash du fichier importé).
+///
+/// L'IBAN de la contrepartie est conservé sous forme de `String` brute à ce
+/// stade : la validation MOD-97 via [`crate::types::Iban`] est laissée à
+/// Story 8-1 pour permettre un import « tolérant » (transaction conservée
+/// même si l'IBAN est mal formé, avec un statut d'avertissement) plutôt
+/// qu'un rejet strict du fichier entier.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BankTransactionDraft {
+    pub booking_date: NaiveDate,
+    pub value_date: Option<NaiveDate>,
+    pub amount: Money,
+    pub currency: String,
+    pub reference: Option<String>,
+    pub details: String,
+    pub end_to_end_id: Option<String>,
+    pub transaction_id: Option<String>,
+    pub counterparty_iban: Option<String>,
+    pub counterparty_name: Option<String>,
+}
+
+impl From<ImportedTransaction> for BankTransactionDraft {
+    fn from(tx: ImportedTransaction) -> Self {
+        Self {
+            booking_date: tx.booking_date,
+            value_date: tx.value_date,
+            amount: Money::new(tx.amount),
+            currency: tx.currency,
+            reference: tx.reference,
+            details: tx.details,
+            end_to_end_id: tx.end_to_end_id,
+            transaction_id: tx.transaction_id,
+            counterparty_iban: tx.counterparty_iban,
+            counterparty_name: tx.counterparty_name,
+        }
+    }
+}
+
+impl From<&ImportedTransaction> for BankTransactionDraft {
+    fn from(tx: &ImportedTransaction) -> Self {
+        Self {
+            booking_date: tx.booking_date,
+            value_date: tx.value_date,
+            amount: Money::new(tx.amount),
+            currency: tx.currency.clone(),
+            reference: tx.reference.clone(),
+            details: tx.details.clone(),
+            end_to_end_id: tx.end_to_end_id.clone(),
+            transaction_id: tx.transaction_id.clone(),
+            counterparty_iban: tx.counterparty_iban.clone(),
+            counterparty_name: tx.counterparty_name.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    fn fixture() -> ImportedTransaction {
+        ImportedTransaction {
+            booking_date: NaiveDate::from_ymd_opt(2026, 5, 2).unwrap(),
+            value_date: Some(NaiveDate::from_ymd_opt(2026, 5, 3).unwrap()),
+            amount: dec!(1234.56),
+            currency: "CHF".to_string(),
+            reference: Some("RF18539007547034".to_string()),
+            details: "Loyer mai 2026".to_string(),
+            end_to_end_id: None,
+            transaction_id: Some("BANK-TX-42".to_string()),
+            counterparty_iban: Some("CH9300762011623852957".to_string()),
+            counterparty_name: Some("Acme SA".to_string()),
+        }
+    }
+
+    #[test]
+    fn from_owned_imported_transaction() {
+        let tx = fixture();
+        let draft: BankTransactionDraft = tx.into();
+        assert_eq!(draft.booking_date, NaiveDate::from_ymd_opt(2026, 5, 2).unwrap());
+        assert_eq!(draft.amount, Money::new(dec!(1234.56)));
+        assert_eq!(draft.currency, "CHF");
+        assert_eq!(draft.reference.as_deref(), Some("RF18539007547034"));
+        assert_eq!(draft.transaction_id.as_deref(), Some("BANK-TX-42"));
+    }
+
+    #[test]
+    fn from_borrowed_imported_transaction_does_not_consume() {
+        let tx = fixture();
+        let draft: BankTransactionDraft = (&tx).into();
+        // tx still usable after the conversion.
+        assert_eq!(tx.amount, dec!(1234.56));
+        assert_eq!(draft.amount, Money::new(dec!(1234.56)));
+    }
+
+    #[test]
+    fn negative_amount_preserved_as_signed_money() {
+        let tx = ImportedTransaction {
+            amount: dec!(-50.00),
+            ..fixture()
+        };
+        let draft: BankTransactionDraft = tx.into();
+        assert!(draft.amount.is_negative());
+        assert_eq!(draft.amount, Money::new(dec!(-50.00)));
+    }
+
+    #[test]
+    fn missing_optional_fields_propagate_as_none() {
+        let tx = ImportedTransaction {
+            value_date: None,
+            reference: None,
+            end_to_end_id: None,
+            transaction_id: None,
+            counterparty_iban: None,
+            counterparty_name: None,
+            ..fixture()
+        };
+        let draft: BankTransactionDraft = tx.into();
+        assert!(draft.value_date.is_none());
+        assert!(draft.reference.is_none());
+        assert!(draft.end_to_end_id.is_none());
+        assert!(draft.transaction_id.is_none());
+        assert!(draft.counterparty_iban.is_none());
+        assert!(draft.counterparty_name.is_none());
+    }
+}

--- a/crates/kesh-core/src/bank_imports.rs
+++ b/crates/kesh-core/src/bank_imports.rs
@@ -111,7 +111,10 @@ mod tests {
     fn from_owned_imported_transaction() {
         let tx = fixture();
         let draft: BankTransactionDraft = tx.into();
-        assert_eq!(draft.booking_date, NaiveDate::from_ymd_opt(2026, 5, 2).unwrap());
+        assert_eq!(
+            draft.booking_date,
+            NaiveDate::from_ymd_opt(2026, 5, 2).unwrap()
+        );
         assert_eq!(draft.amount, Money::new(dec!(1234.56)));
         assert_eq!(draft.currency, "CHF");
         assert_eq!(draft.reference.as_deref(), Some("RF18539007547034"));

--- a/crates/kesh-core/src/lib.rs
+++ b/crates/kesh-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! ou le filesystem.
 
 pub mod accounting;
+pub mod bank_imports;
 pub mod chart_of_accounts;
 pub mod errors;
 pub mod invoice_format;

--- a/crates/kesh-import/Cargo.toml
+++ b/crates/kesh-import/Cargo.toml
@@ -3,5 +3,15 @@ name = "kesh-import"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
+description = "Parseurs CAMT.053 ISO 20022 et CSV multi-encodage pour relevés bancaires"
+repository.workspace = true
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+rust_decimal = { version = "1.41", features = ["serde-str"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+
+[dev-dependencies]
+rust_decimal_macros = "1.40"
+serde_json = "1"

--- a/crates/kesh-import/src/lib.rs
+++ b/crates/kesh-import/src/lib.rs
@@ -1,1 +1,28 @@
-//! Crate placeholder — implementation in subsequent stories.
+//! kesh-import — Parseurs bancaires CAMT.053 et CSV (publiable, zéro dépendance interne).
+//!
+//! Ce crate est volontairement autonome : il ne dépend d'aucun autre crate du
+//! workspace Kesh (`kesh-core`, `kesh-db`, etc.) et ne référence pas leurs
+//! types. Les conversions vers les types domaine de `kesh-core` sont
+//! implémentées **côté `kesh-core`** via `From`/`Into` (cf. décision
+//! architecture #7).
+//!
+//! Cette indépendance permet :
+//!
+//! - Publication indépendante sur crates.io (vérification :
+//!   `cargo publish --dry-run -p kesh-import`).
+//! - Réutilisation par d'autres projets Rust ayant besoin de parser des
+//!   fichiers CAMT.053 ou CSV bancaires.
+//! - Découplage de l'évolution du domaine Kesh par rapport au format de
+//!   relevé bancaire (versions ISO 20022 multiples, profils CSV par banque).
+//!
+//! # Statut spike (2026-05-03)
+//!
+//! Cette première version contient uniquement les types autonomes
+//! [`types::ImportedStatement`] et [`types::ImportedTransaction`].
+//! Les modules `camt053` et `csv` (parseurs effectifs) seront ajoutés par
+//! les Stories 8-1 (CAMT.053) et 8-2 (CSV) — cf.
+//! `_bmad-output/implementation-artifacts/spike-kesh-import.md`.
+
+pub mod types;
+
+pub use types::{ImportedStatement, ImportedTransaction, SourceFormat};

--- a/crates/kesh-import/src/types.rs
+++ b/crates/kesh-import/src/types.rs
@@ -1,0 +1,230 @@
+//! Types autonomes représentant un relevé bancaire importé.
+//!
+//! Aucun champ n'est lié au modèle de persistance Kesh (pas de `bank_account_id`,
+//! `import_id`, `company_id`). Ces clés étrangères sont assignées par
+//! `kesh-core` ou `kesh-api` lors de la conversion vers les types domaine, à
+//! partir du contexte de la requête HTTP (compte bancaire sélectionné par
+//! l'utilisateur, tenant courant, hash du fichier).
+//!
+//! Les types sont volontairement permissifs sur les contenus opaques (IBAN,
+//! références) : la validation stricte (checksum IBAN ISO 13616, format des
+//! références ESR) appartient à `kesh-core`. Le rôle du parseur est d'extraire
+//! les données telles qu'elles apparaissent dans le fichier source, sans les
+//! rejeter prématurément. Un fichier mal formé (XML invalide, colonnes CSV
+//! manquantes) doit échouer à la frontière du parseur ; un fichier
+//! syntaxiquement valide mais contenant un IBAN au checksum incorrect doit
+//! produire un [`ImportedTransaction`] que `kesh-core` rejettera ensuite avec
+//! un message métier explicite.
+
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Format source du relevé importé.
+///
+/// Permet aux consommateurs de tracer la provenance (audit) et de produire
+/// des messages d'erreur adaptés (« CAMT.053 v04 mal formé » vs « ligne CSV
+/// invalide »).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SourceFormat {
+    /// Relevé CAMT.053 ISO 20022. `version` reflète le suffixe de schéma
+    /// (ex. `"001.04"` pour `camt.053.001.04`).
+    Camt053 { version: String },
+    /// Relevé CSV. `encoding` est l'encodage détecté (`"UTF-8"`,
+    /// `"ISO-8859-1"`). `profile_name` référence le profil banque appliqué
+    /// (Story 8-2), `None` si aucun profil n'a matché.
+    Csv {
+        encoding: String,
+        profile_name: Option<String>,
+    },
+}
+
+/// Une transaction unitaire telle qu'extraite d'un relevé.
+///
+/// Le signe d'`amount` suit la convention CAMT.053 du point de vue du compte
+/// titulaire : positif pour un crédit (entrée), négatif pour un débit (sortie).
+/// Les fichiers CSV sont normalisés vers cette convention par le profil banque
+/// (Story 8-2).
+///
+/// Les champs optionnels reflètent les variations entre versions CAMT.053 et
+/// entre banques : `value_date` peut manquer dans certaines exports CSV ;
+/// `end_to_end_id` n'est présent que sur les paiements SEPA structurés ;
+/// `counterparty_iban` peut être omis si la banque ne le transmet pas (espèces).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ImportedTransaction {
+    /// Date de comptabilisation (`<BookgDt>` CAMT.053).
+    pub booking_date: NaiveDate,
+    /// Date valeur (`<ValDt>`), si présente.
+    pub value_date: Option<NaiveDate>,
+    /// Montant signé (positif = crédit titulaire, négatif = débit titulaire).
+    pub amount: Decimal,
+    /// Code devise ISO 4217 (`"CHF"`, `"EUR"`).
+    pub currency: String,
+    /// Référence structurée (ESR/QR-Référence pour les CH, `<CdtrRefInf><Ref>`
+    /// SEPA) si présente.
+    pub reference: Option<String>,
+    /// Détails libres (`<RmtInf><Ustrd>` ou champ texte CSV).
+    pub details: String,
+    /// Identifiant end-to-end fourni par le donneur d'ordre
+    /// (`<EndToEndId>` SEPA), si présent.
+    pub end_to_end_id: Option<String>,
+    /// Identifiant unique attribué par la banque
+    /// (`<AcctSvcrRef>`), si présent. Permet la détection de doublons stricte
+    /// (Story 8-3) en complément de la combinaison
+    /// `date+montant+référence+compte`.
+    pub transaction_id: Option<String>,
+    /// IBAN de la contrepartie si présent (chaîne brute, non validée). La
+    /// validation MOD-97 et le format ISO 13616 sont du ressort de
+    /// `kesh-core::types::Iban` lors de la conversion.
+    pub counterparty_iban: Option<String>,
+    /// Nom de la contrepartie (`<Dbtr><Nm>` ou `<Cdtr><Nm>`), si présent.
+    pub counterparty_name: Option<String>,
+}
+
+/// Un relevé bancaire complet (un fichier CAMT.053 ou un fichier CSV).
+///
+/// Un même fichier CAMT.053 peut contenir plusieurs `<Stmt>`, chacun pour un
+/// compte distinct. Le parseur émet alors un [`ImportedStatement`] par
+/// `<Stmt>`. Pour les CSV, un fichier = un relevé.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ImportedStatement {
+    /// Identifiant du relevé (`<Id>` CAMT.053). `None` pour les CSV qui n'en
+    /// fournissent pas.
+    pub statement_id: Option<String>,
+    /// IBAN du compte titulaire (chaîne brute, non validée).
+    pub account_iban: String,
+    /// Devise du compte (ISO 4217).
+    pub currency: String,
+    /// Solde d'ouverture (`<OpngBal>` CAMT.053). Optionnel pour CSV.
+    pub opening_balance: Option<Decimal>,
+    /// Solde de clôture (`<ClsgBal>` CAMT.053). Optionnel pour CSV.
+    /// Comparé à la somme algébrique des transactions pour détecter les
+    /// fichiers tronqués (CR-010 #62, à intégrer Story 8-1).
+    pub closing_balance: Option<Decimal>,
+    /// Début de la période couverte (`<FrToDt><FrDtTm>`).
+    pub period_from: NaiveDate,
+    /// Fin de la période couverte (`<FrToDt><ToDtTm>`).
+    pub period_to: NaiveDate,
+    /// Liste des transactions du relevé.
+    pub transactions: Vec<ImportedTransaction>,
+    /// Format source et métadonnées de parsing.
+    pub source_format: SourceFormat,
+}
+
+impl ImportedStatement {
+    /// Calcule la somme algébrique des montants des transactions du relevé.
+    ///
+    /// Sert au check « solde de clôture cohérent » prévu par CR-010 (#62) :
+    /// `opening_balance + sum_transactions ≈ closing_balance` à la tolérance
+    /// d'arrondi près (0.01 unité). L'implémentation effective de la
+    /// vérification appartient à Story 8-1.
+    pub fn sum_transactions(&self) -> Decimal {
+        self.transactions.iter().map(|tx| tx.amount).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    fn sample_transaction() -> ImportedTransaction {
+        ImportedTransaction {
+            booking_date: NaiveDate::from_ymd_opt(2026, 5, 2).unwrap(),
+            value_date: Some(NaiveDate::from_ymd_opt(2026, 5, 3).unwrap()),
+            amount: dec!(1234.56),
+            currency: "CHF".to_string(),
+            reference: Some("RF18539007547034".to_string()),
+            details: "Loyer mai 2026".to_string(),
+            end_to_end_id: Some("E2E-2026-05-001".to_string()),
+            transaction_id: Some("BANK-TX-42".to_string()),
+            counterparty_iban: Some("CH9300762011623852957".to_string()),
+            counterparty_name: Some("Acme SA".to_string()),
+        }
+    }
+
+    fn sample_statement() -> ImportedStatement {
+        ImportedStatement {
+            statement_id: Some("STMT-2026-05".to_string()),
+            account_iban: "CH4431999123000889012".to_string(),
+            currency: "CHF".to_string(),
+            opening_balance: Some(dec!(10000.00)),
+            closing_balance: Some(dec!(11234.56)),
+            period_from: NaiveDate::from_ymd_opt(2026, 5, 1).unwrap(),
+            period_to: NaiveDate::from_ymd_opt(2026, 5, 31).unwrap(),
+            transactions: vec![sample_transaction()],
+            source_format: SourceFormat::Camt053 {
+                version: "001.04".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn transaction_serde_roundtrip() {
+        let tx = sample_transaction();
+        let json = serde_json::to_string(&tx).unwrap();
+        let back: ImportedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(tx, back);
+    }
+
+    #[test]
+    fn statement_serde_roundtrip() {
+        let stmt = sample_statement();
+        let json = serde_json::to_string(&stmt).unwrap();
+        let back: ImportedStatement = serde_json::from_str(&json).unwrap();
+        assert_eq!(stmt, back);
+    }
+
+    #[test]
+    fn source_format_camt053_serializes_as_tagged_enum() {
+        let fmt = SourceFormat::Camt053 {
+            version: "001.08".to_string(),
+        };
+        let json = serde_json::to_string(&fmt).unwrap();
+        assert!(json.contains(r#""kind":"camt053""#));
+        assert!(json.contains(r#""version":"001.08""#));
+    }
+
+    #[test]
+    fn source_format_csv_carries_encoding_and_profile() {
+        let fmt = SourceFormat::Csv {
+            encoding: "ISO-8859-1".to_string(),
+            profile_name: Some("UBS".to_string()),
+        };
+        let json = serde_json::to_string(&fmt).unwrap();
+        let back: SourceFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, back);
+    }
+
+    #[test]
+    fn amount_preserves_decimal_precision() {
+        // rust_decimal preserves trailing zeros via serde-str.
+        let tx = ImportedTransaction {
+            amount: dec!(0.01),
+            ..sample_transaction()
+        };
+        let json = serde_json::to_string(&tx).unwrap();
+        assert!(json.contains(r#""amount":"0.01""#));
+    }
+
+    #[test]
+    fn sum_transactions_matches_expected_delta() {
+        let mut stmt = sample_statement();
+        stmt.transactions.push(ImportedTransaction {
+            amount: dec!(-100.00),
+            ..sample_transaction()
+        });
+        // 1234.56 + (-100.00) = 1134.56
+        assert_eq!(stmt.sum_transactions(), dec!(1134.56));
+    }
+
+    #[test]
+    fn negative_amount_signals_debit() {
+        let tx = ImportedTransaction {
+            amount: dec!(-50.00),
+            ..sample_transaction()
+        };
+        assert!(tx.amount.is_sign_negative());
+    }
+}


### PR DESCRIPTION
## Summary

- Spike Epic 8 prep critical path item #4 (cf. [`epic-7-retro-2026-05-01.md`](_bmad-output/implementation-artifacts/epic-7-retro-2026-05-01.md)) : valide la décision archi #7 (types autonomes par crate, conversion via `From`/`Into` côté Kesh) et la décision archi #6 (`kesh-import` publiable, zéro dep workspace) avec un POC fonctionnel.
- Ajoute dans `kesh-import` les types autonomes `ImportedStatement`, `ImportedTransaction`, `SourceFormat` (chrono + rust_decimal + serde + thiserror seulement). Verdict du spike : **feasible**, le critical path Epic 8 est désormais 5/5 clos.
- Le scaffold `kesh-core::bank_imports::BankTransactionDraft` est volontairement minimal — Story 8-1 l'étendra (FK injection, stratégie tolérance IBAN, mapping devise, check CR-010 [#62](https://github.com/guycorbaz/kesh/issues/62)).

## Vérifications

- `cargo build -p kesh-import` ✅
- `cargo test -p kesh-import` → 7/7 passed
- `cargo test -p kesh-core` → 138/138 passed (134 existants + 4 conversion, zéro régression)
- `cargo build --workspace` ✅ (kesh-api, kesh-db, kesh-seed inclus)
- `cargo publish --dry-run -p kesh-import` ✅ — AC Story 8-1 « publishable » pré-validé

## Test plan

- [x] Tests unitaires `kesh-import` (serde round-trip, signe debit/credit, sum_transactions, source_format tagged enum)
- [x] Tests conversion `kesh-core::bank_imports` (From owned/borrowed, optional fields, signed amount preservation)
- [x] Build du workspace complet
- [x] `cargo publish --dry-run -p kesh-import` sans erreur

## Decision doc

[`_bmad-output/implementation-artifacts/spike-kesh-import.md`](_bmad-output/implementation-artifacts/spike-kesh-import.md) — inventaire des types, choix de design, risques résiduels (RS-1 à RS-4), follow-ups Story 8-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)