### PR TITLE
chore(pages): GitHub Pages marketing site for Kesh

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,43 @@
+name: Deploy GitHub Pages
+
+# Deploy the static marketing site under `website/` to GitHub Pages.
+# Runs on every push to main that touches `website/` or this workflow file.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/404.html
+++ b/website/404.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>404 — Kesh</title>
+	<meta name="theme-color" content="#0f172a" />
+	<link rel="icon" type="image/svg+xml" href="img/logo.svg" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+	<script src="https://cdn.tailwindcss.com"></script>
+	<link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen flex flex-col">
+	<header class="border-b border-slate-800">
+		<nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center">
+			<a href="/" class="flex items-center gap-3">
+				<img src="img/logo.svg" alt="Kesh logo" class="w-9 h-9" />
+				<span class="text-xl font-bold tracking-tight">Kesh</span>
+			</a>
+		</nav>
+	</header>
+
+	<main class="flex-1 flex items-center justify-center px-4">
+		<div class="text-center">
+			<p class="text-emerald-400 font-mono text-sm mb-4">// 404</p>
+			<h1 class="text-5xl sm:text-6xl font-extrabold tracking-tight mb-4">Page not found.</h1>
+			<p class="text-slate-400 mb-8 max-w-md mx-auto">The page you are looking for does not exist or has moved.</p>
+			<a href="/" class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">
+				← Back to home
+			</a>
+		</div>
+	</main>
+
+	<footer class="border-t border-slate-800">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 text-center text-sm text-slate-500">
+			<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+		</div>
+	</footer>
+</body>
+</html>

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,51 @@
+# Kesh marketing website
+
+Static HTML site published to GitHub Pages from `website/` on every push to `main`.
+
+## Stack
+
+- **HTML5** — no framework, no build step.
+- **Tailwind CSS** via [Play CDN](https://tailwindcss.com/docs/installation/play-cdn) — modify classes directly in HTML, refresh.
+- **Inter** + **JetBrains Mono** via Google Fonts.
+- Custom CSS in `css/style.css` for hero gradient, animations, focus rings, reduced-motion support.
+
+## Pages
+
+| File | Path | Purpose |
+|------|------|---------|
+| `index.html` | `/` | Homepage — hero, features, tech stack, CTA |
+| `about.html` | `/about.html` | Mission, architecture, Swiss compliance, BMAD methodology |
+| `roadmap.html` | `/roadmap.html` | Visual epic timeline (v0.1 + v0.2) |
+| `issues.html` | `/issues.html` | Issue templates and label-based deep links |
+| `404.html` | served on unknown path | GitHub Pages renders this automatically on 404 |
+
+## Local preview
+
+Any static server works:
+
+```sh
+cd website
+python3 -m http.server 8000
+# → http://localhost:8000
+```
+
+## Deployment
+
+Triggered by `.github/workflows/deploy-pages.yml` on every push to `main` that touches `website/**`. The workflow uploads `website/` as a Pages artifact via `actions/upload-pages-artifact@v3`.
+
+### One-time setup (repo admin)
+
+In **Settings → Pages** of the GitHub repository:
+
+1. **Source**: select **GitHub Actions** (not the legacy "Deploy from a branch").
+2. The first successful workflow run publishes the site to `https://guycorbaz.github.io/kesh/`.
+
+A custom domain can be configured later by adding a `CNAME` file with the domain inside this `website/` directory, plus a DNS record at the registrar.
+
+## Editing
+
+- **Copy / wording** → edit the relevant `.html` file directly.
+- **Visual tweaks** → modify Tailwind utility classes in HTML. For repeated patterns, add a class to `css/style.css`.
+- **New page** → copy `about.html` as a template (preserves nav, footer, and font setup).
+
+The `.nojekyll` file disables Jekyll preprocessing so file paths starting with `_` work as expected.

--- a/website/about.html
+++ b/website/about.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>About — Kesh</title>
+	<meta name="description" content="Kesh project — mission, architecture, BMAD methodology, and Swiss compliance focus." />
+	<meta name="theme-color" content="#0f172a" />
+	<link rel="icon" type="image/svg+xml" href="img/logo.svg" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+	<script src="https://cdn.tailwindcss.com"></script>
+	<script>
+		tailwind.config = { darkMode: 'class' };
+	</script>
+	<link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen">
+
+	<header class="sticky top-0 z-50 backdrop-blur-md bg-slate-950/70 border-b border-slate-800">
+		<nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+			<a href="index.html" class="flex items-center gap-3 group">
+				<img src="img/logo.svg" alt="Kesh logo" class="w-9 h-9 transition-transform group-hover:scale-110" />
+				<span class="text-xl font-bold tracking-tight">Kesh</span>
+			</a>
+			<div class="hidden md:flex items-center gap-8 text-sm font-medium">
+				<a href="index.html" class="text-slate-300 hover:text-white transition-colors">Home</a>
+				<a href="about.html" class="text-emerald-400">About</a>
+				<a href="roadmap.html" class="text-slate-300 hover:text-white transition-colors">Roadmap</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="text-slate-300 hover:text-white transition-colors">Issues</a>
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">GitHub</a>
+			</div>
+		</nav>
+	</header>
+
+	<!-- Hero -->
+	<section class="relative overflow-hidden border-b border-slate-800">
+		<div class="absolute inset-0 hero-gradient"></div>
+		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+			<p class="text-emerald-400 text-sm font-mono mb-3">// About the project</p>
+			<h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight mb-6">An open accounting platform, built for Switzerland.</h1>
+			<p class="text-lg text-slate-300 leading-relaxed">Kesh is being designed and developed in the open as a free alternative to proprietary Swiss accounting software. It targets independents, SMEs, and associations who want to keep their financial data on their own infrastructure — without sacrificing the workflows and compliance features they actually need.</p>
+		</div>
+	</section>
+
+	<!-- Mission -->
+	<section class="border-b border-slate-800">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-8">Mission</h2>
+			<div class="space-y-5 text-slate-300 leading-relaxed">
+				<p>Most accounting software for the Swiss market is closed-source, expensive, and cloud-only. Even the open-source options are rarely focused on Swiss specificities: the QR-Bill payment slip, the ISO 20022 banking flows mandated since 2018, the four official languages, and the locale conventions that small accountants and fiduciaries rely on every day.</p>
+				<p>Kesh exists to fill this gap. It is built around three commitments:</p>
+				<ul class="space-y-3 list-disc list-inside marker:text-emerald-400">
+					<li><strong class="text-white">Swiss-first.</strong> QR Bill 2.2, CAMT.053, pain.001, multilingual UI, and a chart of accounts adapted to Swiss practice.</li>
+					<li><strong class="text-white">Self-hosted.</strong> Single-binary deployment via Docker Compose. Your accounting data never leaves your servers unless you choose to back it up off-site.</li>
+					<li><strong class="text-white">Free, forever.</strong> Released under the European Union Public Licence (EUPL 1.2). No tiers, no feature paywall.</li>
+				</ul>
+			</div>
+		</div>
+	</section>
+
+	<!-- Architecture -->
+	<section class="border-b border-slate-800 bg-slate-900/30">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-8">Architecture</h2>
+			<div class="grid sm:grid-cols-2 gap-6">
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="text-lg font-semibold mb-2 text-emerald-400">Backend — Rust workspace</h3>
+					<p class="text-sm text-slate-400 mb-3">A multi-crate Cargo workspace cleanly separates business logic from I/O concerns.</p>
+					<ul class="text-sm text-slate-300 space-y-1.5 font-mono">
+						<li><code>kesh-core</code> — pure types, validation</li>
+						<li><code>kesh-db</code> — persistence, migrations</li>
+						<li><code>kesh-api</code> — Axum HTTP layer</li>
+						<li><code>kesh-qrbill</code> — QR Bill 2.2</li>
+						<li><code>kesh-import</code> — CAMT.053, CSV</li>
+						<li><code>kesh-payment</code> — pain.001 (planned)</li>
+						<li><code>kesh-i18n</code> — Fluent i18n</li>
+					</ul>
+				</div>
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="text-lg font-semibold mb-2 text-emerald-400">Frontend — SvelteKit 2</h3>
+					<p class="text-sm text-slate-400 mb-3">A modern SvelteKit SPA with Tailwind CSS 4 and TypeScript end-to-end.</p>
+					<ul class="text-sm text-slate-300 space-y-1.5">
+						<li>Svelte 5 (runes mode)</li>
+						<li>Tailwind CSS 4</li>
+						<li>Vitest unit tests</li>
+						<li>Playwright E2E coverage</li>
+						<li>i18n via Fluent (FR/DE/IT/EN)</li>
+					</ul>
+				</div>
+			</div>
+
+			<div class="mt-8 p-6 rounded-xl bg-slate-900 border border-slate-800">
+				<h3 class="text-lg font-semibold mb-2">Multi-tenant by design</h3>
+				<p class="text-sm text-slate-400 leading-relaxed">Every JWT carries a <code class="text-emerald-400">company_id</code> claim. Every database query filters by that claim — defence in depth against IDOR. Companies are isolated at the row level, not just at the application layer.</p>
+			</div>
+		</div>
+	</section>
+
+	<!-- Compliance -->
+	<section class="border-b border-slate-800">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-8">Swiss compliance</h2>
+			<div class="grid sm:grid-cols-2 gap-4">
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">QR Bill 2.2</h3>
+					<p class="text-sm text-slate-400">Pixel-perfect generation per the SIX Swiss Payment Standards Implementation Guidelines.</p>
+				</div>
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">CAMT.053.001.04</h3>
+					<p class="text-sm text-slate-400">ISO 20022 bank statement import — required for automated reconciliation since 2018.</p>
+				</div>
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">pain.001.001.03</h3>
+					<p class="text-sm text-slate-400">Outgoing payment files in the format expected by Swiss banks (planned for v0.2).</p>
+				</div>
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">Swiss VAT</h3>
+					<p class="text-sm text-slate-400">Per-period VAT computation and reporting (planned for v0.2).</p>
+				</div>
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">Locale conventions</h3>
+					<p class="text-sm text-slate-400">Date format <code>dd.mm.yyyy</code>, thousands separator with apostrophe (1'234.50), CHF currency.</p>
+				</div>
+				<div class="p-5 rounded-lg border border-slate-800 bg-slate-900/50">
+					<h3 class="font-semibold mb-1">Four languages</h3>
+					<p class="text-sm text-slate-400">French, German, Italian, English — the four working languages of Swiss business.</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- BMAD -->
+	<section class="border-b border-slate-800 bg-slate-900/30">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-4">Built with BMAD</h2>
+			<p class="text-slate-300 leading-relaxed mb-6">Kesh is developed using the <strong class="text-white">BMAD (Breakthrough Method of Agile AI-driven Development)</strong> methodology — a structured, story-driven workflow that emphasises explicit specifications, multi-pass adversarial review, and immutable change logs. Every story flows through the same gates:</p>
+			<div class="space-y-3">
+				<div class="flex gap-4 p-4 rounded-lg border border-slate-800 bg-slate-900/50">
+					<span class="font-mono text-emerald-400 shrink-0">1.</span>
+					<div>
+						<h3 class="font-semibold">Spec creation</h3>
+						<p class="text-sm text-slate-400">Acceptance criteria, technical design, test plan — written before any code.</p>
+					</div>
+				</div>
+				<div class="flex gap-4 p-4 rounded-lg border border-slate-800 bg-slate-900/50">
+					<span class="font-mono text-emerald-400 shrink-0">2.</span>
+					<div>
+						<h3 class="font-semibold">Spec validation (multi-pass)</h3>
+						<p class="text-sm text-slate-400">Adversarial review across multiple LLMs (Opus → Sonnet → Haiku rotation) until zero <code>MEDIUM+</code> findings remain.</p>
+					</div>
+				</div>
+				<div class="flex gap-4 p-4 rounded-lg border border-slate-800 bg-slate-900/50">
+					<span class="font-mono text-emerald-400 shrink-0">3.</span>
+					<div>
+						<h3 class="font-semibold">Implementation</h3>
+						<p class="text-sm text-slate-400">Test-driven development, full CI green locally before push.</p>
+					</div>
+				</div>
+				<div class="flex gap-4 p-4 rounded-lg border border-slate-800 bg-slate-900/50">
+					<span class="font-mono text-emerald-400 shrink-0">4.</span>
+					<div>
+						<h3 class="font-semibold">Code review (multi-pass)</h3>
+						<p class="text-sm text-slate-400">Same adversarial loop on the implementation. Same convergence criterion.</p>
+					</div>
+				</div>
+				<div class="flex gap-4 p-4 rounded-lg border border-slate-800 bg-slate-900/50">
+					<span class="font-mono text-emerald-400 shrink-0">5.</span>
+					<div>
+						<h3 class="font-semibold">Retrospective</h3>
+						<p class="text-sm text-slate-400">At the end of each epic — capture the lessons that change how the next epic is built.</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- License -->
+	<section>
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-4">License</h2>
+			<p class="text-slate-300 leading-relaxed mb-4">Kesh is distributed under the <a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12" target="_blank" rel="noopener" class="text-emerald-400 underline hover:no-underline">European Union Public Licence v1.2 (EUPL 1.2)</a> — an OSI-approved copyleft licence, drafted by the European Commission, and explicitly compatible with the GPL family.</p>
+			<p class="text-slate-300 leading-relaxed">You can run it, modify it, and redistribute it, including commercially. If you distribute a modified version, you publish your changes under the same terms.</p>
+		</div>
+	</section>
+
+	<footer class="border-t border-slate-800 bg-slate-950">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+			<div class="flex items-center gap-3">
+				<img src="img/logo.svg" alt="" class="w-7 h-7 opacity-70" />
+				<span>Kesh — open-source Swiss accounting</span>
+			</div>
+			<div class="flex items-center gap-6">
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="hover:text-white transition-colors">Issues</a>
+				<a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12" target="_blank" rel="noopener" class="hover:text-white transition-colors">EUPL 1.2</a>
+			</div>
+		</div>
+	</footer>
+</body>
+</html>

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1,0 +1,100 @@
+/* Kesh website — custom styles complementing Tailwind CDN. */
+
+:root {
+	color-scheme: dark light;
+}
+
+/* Smooth font rendering. */
+html {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	scroll-behavior: smooth;
+}
+
+body {
+	font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+		Roboto, sans-serif;
+	font-feature-settings: 'cv11', 'ss01', 'ss03';
+}
+
+/* Hero gradient — Swiss-inspired but tech-modern. */
+.hero-gradient {
+	background:
+		radial-gradient(circle at 20% 0%, rgba(16, 185, 129, 0.12) 0%, transparent 45%),
+		radial-gradient(circle at 80% 30%, rgba(59, 130, 246, 0.10) 0%, transparent 50%),
+		radial-gradient(circle at 50% 100%, rgba(239, 68, 68, 0.08) 0%, transparent 55%);
+}
+
+/* Subtle grid background for texture. */
+.bg-grid {
+	background-image:
+		linear-gradient(rgba(148, 163, 184, 0.05) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(148, 163, 184, 0.05) 1px, transparent 1px);
+	background-size: 32px 32px;
+}
+
+/* Pulse animation for status badges. */
+@keyframes pulse-glow {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.6; }
+}
+.pulse-glow {
+	animation: pulse-glow 2s ease-in-out infinite;
+}
+
+/* Fade-in for hero. */
+@keyframes fade-up {
+	from {
+		opacity: 0;
+		transform: translateY(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+.animate-fade-up {
+	animation: fade-up 0.6s ease-out backwards;
+}
+.animate-fade-up.delay-1 { animation-delay: 0.1s; }
+.animate-fade-up.delay-2 { animation-delay: 0.2s; }
+.animate-fade-up.delay-3 { animation-delay: 0.3s; }
+
+/* Code blocks. */
+code {
+	font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular,
+		Menlo, monospace;
+	font-size: 0.92em;
+}
+
+/* Smooth focus rings. */
+*:focus-visible {
+	outline: 2px solid #10b981;
+	outline-offset: 2px;
+	border-radius: 4px;
+}
+
+/* Reduce motion preferences. */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+	html { scroll-behavior: auto; }
+}
+
+/* Roadmap timeline connector. */
+.timeline-line {
+	position: absolute;
+	left: 1.5rem;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: linear-gradient(to bottom,
+		rgba(16, 185, 129, 0.3) 0%,
+		rgba(59, 130, 246, 0.3) 50%,
+		rgba(148, 163, 184, 0.2) 100%);
+}

--- a/website/img/logo.svg
+++ b/website/img/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Kesh logo">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#grad)"/>
+  <path d="M22 18 L22 46 M22 32 L36 18 M22 32 L36 46 M40 18 L40 46" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="48" cy="46" r="3" fill="white"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Kesh — Open-source Swiss accounting & invoicing</title>
+	<meta name="description" content="Kesh is a free, open-source, self-hosted accounting and management software for Swiss freelancers, SMEs, and associations. Built with Rust, SvelteKit, and MariaDB." />
+	<meta name="theme-color" content="#0f172a" />
+	<link rel="icon" type="image/svg+xml" href="img/logo.svg" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+	<script src="https://cdn.tailwindcss.com"></script>
+	<script>
+		tailwind.config = {
+			darkMode: 'class',
+			theme: {
+				extend: {
+					colors: {
+						accent: { DEFAULT: '#10b981', soft: '#10b98115' },
+					},
+				},
+			},
+		};
+	</script>
+	<link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen">
+
+	<!-- Navigation -->
+	<header class="sticky top-0 z-50 backdrop-blur-md bg-slate-950/70 border-b border-slate-800">
+		<nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+			<a href="index.html" class="flex items-center gap-3 group">
+				<img src="img/logo.svg" alt="Kesh logo" class="w-9 h-9 transition-transform group-hover:scale-110" />
+				<span class="text-xl font-bold tracking-tight">Kesh</span>
+			</a>
+			<div class="hidden md:flex items-center gap-8 text-sm font-medium">
+				<a href="index.html" class="text-emerald-400">Home</a>
+				<a href="about.html" class="text-slate-300 hover:text-white transition-colors">About</a>
+				<a href="roadmap.html" class="text-slate-300 hover:text-white transition-colors">Roadmap</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="text-slate-300 hover:text-white transition-colors">Issues</a>
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">
+					<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+					GitHub
+				</a>
+			</div>
+			<button id="menu-toggle" class="md:hidden text-slate-300 hover:text-white" aria-label="Toggle menu">
+				<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+			</button>
+		</nav>
+		<div id="mobile-menu" class="hidden md:hidden border-t border-slate-800 bg-slate-950">
+			<div class="flex flex-col gap-4 px-4 py-4 text-sm">
+				<a href="index.html" class="text-emerald-400">Home</a>
+				<a href="about.html" class="text-slate-300">About</a>
+				<a href="roadmap.html" class="text-slate-300">Roadmap</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="text-slate-300">Issues</a>
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="text-emerald-400 font-semibold">GitHub →</a>
+			</div>
+		</div>
+	</header>
+
+	<!-- Hero -->
+	<section class="relative overflow-hidden">
+		<div class="absolute inset-0 bg-grid opacity-50"></div>
+		<div class="absolute inset-0 hero-gradient"></div>
+		<div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32 lg:py-40">
+			<div class="max-w-4xl mx-auto text-center">
+				<div class="animate-fade-up inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 text-sm font-medium mb-6">
+					<span class="w-2 h-2 rounded-full bg-emerald-400 pulse-glow"></span>
+					v0.1 in active development
+				</div>
+				<h1 class="animate-fade-up delay-1 text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6">
+					Open-source <span class="bg-gradient-to-r from-emerald-400 via-blue-400 to-emerald-500 bg-clip-text text-transparent">Swiss accounting</span> &amp; invoicing
+				</h1>
+				<p class="animate-fade-up delay-2 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto mb-10 leading-relaxed">
+					Kesh is a free, self-hosted accounting and management platform for Swiss freelancers, SMEs, and associations. QR Bill 2.2, CAMT.053 import, multi-tenant, multilingual.
+				</p>
+				<div class="animate-fade-up delay-3 flex flex-col sm:flex-row gap-4 justify-center">
+					<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">
+						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+						View on GitHub
+					</a>
+					<a href="roadmap.html" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg border border-slate-700 hover:border-slate-500 hover:bg-slate-800/50 transition-colors text-slate-100 font-semibold">
+						Roadmap
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+					</a>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Key features -->
+	<section class="border-t border-slate-800 bg-slate-900/50">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+			<div class="text-center mb-14">
+				<h2 class="text-3xl sm:text-4xl font-bold tracking-tight mb-4">Built for Swiss financial workflows</h2>
+				<p class="text-slate-400 max-w-2xl mx-auto">Compliance, security, and a modern stack — designed from day one for freelancers, SMEs, and accounting professionals.</p>
+			</div>
+
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Double-entry bookkeeping</h3>
+					<p class="text-sm text-slate-400">Swiss chart of accounts, validated journal entries, immutable audit log.</p>
+				</div>
+
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">QR Bill 2.2</h3>
+					<p class="text-sm text-slate-400">Pixel-perfect Swiss QR-Bill PDF generation, fully compliant with SIX 2.2 specification.</p>
+				</div>
+
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">CAMT.053 + CSV import</h3>
+					<p class="text-sm text-slate-400">Bank statement import in ISO 20022 CAMT.053 format and configurable CSV profiles per bank.</p>
+				</div>
+
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Multilingual</h3>
+					<p class="text-sm text-slate-400">French, German, Italian, English. Locale-aware formatting (apostrophes for thousands, dd.mm.yyyy dates).</p>
+				</div>
+
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Multi-tenant &amp; RBAC</h3>
+					<p class="text-sm text-slate-400">Strict company-level isolation, role-based access control, JWT + refresh tokens.</p>
+				</div>
+
+				<div class="p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Self-hosted &amp; free</h3>
+					<p class="text-sm text-slate-400">EUPL 1.2 license. Docker Compose deployment. Your data stays on your infrastructure.</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Tech stack -->
+	<section class="border-t border-slate-800">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+			<div class="grid lg:grid-cols-2 gap-12 items-center">
+				<div>
+					<h2 class="text-3xl sm:text-4xl font-bold tracking-tight mb-4">Modern, type-safe stack</h2>
+					<p class="text-slate-400 mb-6 leading-relaxed">Kesh is built on a deliberately conservative selection of modern, type-safe technologies. The accounting engine is pure Rust with comprehensive unit tests; the web layer uses Axum and SvelteKit for performance and DX.</p>
+					<dl class="space-y-3 text-sm">
+						<div class="flex gap-3">
+							<dt class="text-emerald-400 font-mono w-24 shrink-0">Backend</dt>
+							<dd class="text-slate-300">Rust 1.85 (edition 2024), Axum, SQLx</dd>
+						</div>
+						<div class="flex gap-3">
+							<dt class="text-emerald-400 font-mono w-24 shrink-0">Frontend</dt>
+							<dd class="text-slate-300">SvelteKit 2 + Svelte 5, TypeScript, Tailwind CSS 4</dd>
+						</div>
+						<div class="flex gap-3">
+							<dt class="text-emerald-400 font-mono w-24 shrink-0">Database</dt>
+							<dd class="text-slate-300">MariaDB 11.4</dd>
+						</div>
+						<div class="flex gap-3">
+							<dt class="text-emerald-400 font-mono w-24 shrink-0">Deploy</dt>
+							<dd class="text-slate-300">Docker Compose</dd>
+						</div>
+						<div class="flex gap-3">
+							<dt class="text-emerald-400 font-mono w-24 shrink-0">Testing</dt>
+							<dd class="text-slate-300">cargo test, Vitest, Playwright</dd>
+						</div>
+					</dl>
+				</div>
+				<div class="relative">
+					<div class="absolute -inset-4 bg-gradient-to-r from-emerald-500/20 to-blue-500/20 rounded-2xl blur-xl"></div>
+					<pre class="relative rounded-xl border border-slate-800 bg-slate-900 p-6 text-sm overflow-x-auto"><code class="text-slate-200"><span class="text-slate-500"># Quick start</span>
+git clone https://github.com/guycorbaz/kesh.git
+<span class="text-emerald-400">cd</span> kesh
+
+<span class="text-slate-500"># Start MariaDB + backend</span>
+docker compose -f docker-compose.dev.yml up -d
+
+<span class="text-slate-500"># Frontend (hot reload)</span>
+<span class="text-emerald-400">cd</span> frontend &amp;&amp; npm install &amp;&amp; npm run dev
+
+<span class="text-slate-500"># → http://localhost:5173</span></code></pre>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- CTA -->
+	<section class="border-t border-slate-800 bg-gradient-to-b from-slate-900/50 to-slate-950">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-20 text-center">
+			<h2 class="text-3xl sm:text-4xl font-bold tracking-tight mb-4">Get involved</h2>
+			<p class="text-slate-400 mb-8 max-w-2xl mx-auto">Kesh is in active development under the EUPL 1.2 license. Contributions, bug reports, and feature requests are welcome.</p>
+			<div class="flex flex-col sm:flex-row gap-4 justify-center">
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">
+					Browse issues
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="about.html" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg border border-slate-700 hover:border-slate-500 hover:bg-slate-800/50 transition-colors text-slate-100 font-semibold">
+					Learn more
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<!-- Footer -->
+	<footer class="border-t border-slate-800 bg-slate-950">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+			<div class="flex items-center gap-3">
+				<img src="img/logo.svg" alt="" class="w-7 h-7 opacity-70" />
+				<span>Kesh — open-source Swiss accounting</span>
+			</div>
+			<div class="flex items-center gap-6">
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="hover:text-white transition-colors">Issues</a>
+				<a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12" target="_blank" rel="noopener" class="hover:text-white transition-colors">EUPL 1.2</a>
+			</div>
+		</div>
+	</footer>
+
+	<script>
+		// Mobile menu toggle.
+		const toggle = document.getElementById('menu-toggle');
+		const menu = document.getElementById('mobile-menu');
+		if (toggle && menu) {
+			toggle.addEventListener('click', () => menu.classList.toggle('hidden'));
+		}
+	</script>
+</body>
+</html>

--- a/website/issues.html
+++ b/website/issues.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Issues &amp; Contributions — Kesh</title>
+	<meta name="description" content="Report bugs, request features, or browse known failures for the Kesh project on GitHub." />
+	<meta name="theme-color" content="#0f172a" />
+	<link rel="icon" type="image/svg+xml" href="img/logo.svg" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+	<script src="https://cdn.tailwindcss.com"></script>
+	<script>
+		tailwind.config = { darkMode: 'class' };
+	</script>
+	<link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen">
+
+	<header class="sticky top-0 z-50 backdrop-blur-md bg-slate-950/70 border-b border-slate-800">
+		<nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+			<a href="index.html" class="flex items-center gap-3 group">
+				<img src="img/logo.svg" alt="Kesh logo" class="w-9 h-9 transition-transform group-hover:scale-110" />
+				<span class="text-xl font-bold tracking-tight">Kesh</span>
+			</a>
+			<div class="hidden md:flex items-center gap-8 text-sm font-medium">
+				<a href="index.html" class="text-slate-300 hover:text-white transition-colors">Home</a>
+				<a href="about.html" class="text-slate-300 hover:text-white transition-colors">About</a>
+				<a href="roadmap.html" class="text-slate-300 hover:text-white transition-colors">Roadmap</a>
+				<a href="issues.html" class="text-emerald-400">Issues</a>
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">GitHub</a>
+			</div>
+		</nav>
+	</header>
+
+	<!-- Hero -->
+	<section class="relative overflow-hidden border-b border-slate-800">
+		<div class="absolute inset-0 hero-gradient"></div>
+		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+			<p class="text-emerald-400 text-sm font-mono mb-3">// Issues &amp; contributions</p>
+			<h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight mb-6">GitHub Issues is the single source of truth.</h1>
+			<p class="text-lg text-slate-300 leading-relaxed">All bug reports, feature requests, and known failures live in <a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="text-emerald-400 underline hover:no-underline">guycorbaz/kesh/issues</a>. Each issue uses one of three templates so it lands with the right labels and triage flow.</p>
+		</div>
+	</section>
+
+	<!-- Issue templates -->
+	<section class="border-b border-slate-800">
+		<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-10 text-center">Pick the right template</h2>
+			<div class="grid md:grid-cols-3 gap-6">
+
+				<a href="https://github.com/guycorbaz/kesh/issues/new?template=bug_report.yml" target="_blank" rel="noopener" class="group p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-red-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-red-500/10 border border-red-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Bug report</h3>
+					<p class="text-sm text-slate-400 mb-4">Something is broken or behaving incorrectly. Reproduction steps, observed vs expected behaviour, and environment details.</p>
+					<div class="text-xs font-mono text-slate-500">labels: <span class="text-red-400">bug</span>, <span class="text-amber-400">triage</span></div>
+					<div class="mt-3 text-sm text-emerald-400 font-medium opacity-0 group-hover:opacity-100 transition-opacity">Open template →</div>
+				</a>
+
+				<a href="https://github.com/guycorbaz/kesh/issues/new?template=known_failure.yml" target="_blank" rel="noopener" class="group p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-amber-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-amber-500/10 border border-amber-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Known failure (KF)</h3>
+					<p class="text-sm text-slate-400 mb-4">A failing test or defective behaviour outside the scope of current work. Tracked, prioritised, but not blocking the active sprint.</p>
+					<div class="text-xs font-mono text-slate-500">labels: <span class="text-amber-400">known-failure</span>, <span class="text-amber-400">triage</span></div>
+					<div class="mt-3 text-sm text-emerald-400 font-medium opacity-0 group-hover:opacity-100 transition-opacity">Open template →</div>
+				</a>
+
+				<a href="https://github.com/guycorbaz/kesh/issues/new?template=feature_request.yml" target="_blank" rel="noopener" class="group p-6 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<div class="w-12 h-12 rounded-lg bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center mb-4">
+						<svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+					</div>
+					<h3 class="text-lg font-semibold mb-2">Feature / Change request</h3>
+					<p class="text-sm text-slate-400 mb-4">A new feature or a scope change to a planned story. Use this <em>before</em> changing scope on validated stories.</p>
+					<div class="text-xs font-mono text-slate-500">labels: <span class="text-emerald-400">enhancement</span>, <span class="text-amber-400">triage</span></div>
+					<div class="mt-3 text-sm text-emerald-400 font-medium opacity-0 group-hover:opacity-100 transition-opacity">Open template →</div>
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<!-- Quick links -->
+	<section class="border-b border-slate-800 bg-slate-900/30">
+		<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-8 text-center">Browse by label</h2>
+			<div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+				<a href="https://github.com/guycorbaz/kesh/issues?q=is%3Aopen+is%3Aissue+label%3Abug" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-600 transition-colors">
+					<span class="font-mono text-sm">label:bug</span>
+					<svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="https://github.com/guycorbaz/kesh/issues?q=is%3Aopen+is%3Aissue+label%3Aknown-failure" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-600 transition-colors">
+					<span class="font-mono text-sm">label:known-failure</span>
+					<svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="https://github.com/guycorbaz/kesh/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-600 transition-colors">
+					<span class="font-mono text-sm">label:enhancement</span>
+					<svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="https://github.com/guycorbaz/kesh/issues?q=is%3Aopen+is%3Aissue+label%3Atriage" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-600 transition-colors">
+					<span class="font-mono text-sm">label:triage</span>
+					<svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="https://github.com/guycorbaz/kesh/issues?q=is%3Aopen+is%3Aissue+label%3Atechnical-debt" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-slate-600 transition-colors">
+					<span class="font-mono text-sm">label:technical-debt</span>
+					<svg class="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="flex items-center justify-between p-4 rounded-lg bg-slate-900 border border-slate-800 hover:border-emerald-500/50 transition-colors">
+					<span class="font-mono text-sm text-emerald-400">all open issues</span>
+					<svg class="w-4 h-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+				</a>
+			</div>
+		</div>
+	</section>
+
+	<!-- Contributing -->
+	<section>
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<h2 class="text-3xl font-bold tracking-tight mb-4">Contributing code</h2>
+			<p class="text-slate-300 leading-relaxed mb-4">Pull requests are welcome. Before submitting a PR with significant scope, please open an issue first so the change can be discussed.</p>
+			<ul class="space-y-2 text-slate-300 list-disc list-inside marker:text-emerald-400">
+				<li>Follow the code-quality rules in <code class="text-emerald-400">CLAUDE.md</code> (DRY, documentation, tests).</li>
+				<li>Add unit tests for any business logic, especially around accounting and VAT.</li>
+				<li>Run the full local CI checks (<code>cargo fmt</code>, <code>cargo clippy</code>, <code>cargo test</code>, <code>npm run check</code>) before pushing.</li>
+				<li>Write commit messages that reference the related issue (e.g. <code>fix: round invoice totals (refs #42)</code>).</li>
+			</ul>
+		</div>
+	</section>
+
+	<footer class="border-t border-slate-800 bg-slate-950">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+			<div class="flex items-center gap-3">
+				<img src="img/logo.svg" alt="" class="w-7 h-7 opacity-70" />
+				<span>Kesh — open-source Swiss accounting</span>
+			</div>
+			<div class="flex items-center gap-6">
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="hover:text-white transition-colors">Issues</a>
+				<a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12" target="_blank" rel="noopener" class="hover:text-white transition-colors">EUPL 1.2</a>
+			</div>
+		</div>
+	</footer>
+</body>
+</html>

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Roadmap — Kesh</title>
+	<meta name="description" content="Kesh release roadmap — v0.1 foundations, v0.2 Swiss VAT and payments, planned epics and current status." />
+	<meta name="theme-color" content="#0f172a" />
+	<link rel="icon" type="image/svg+xml" href="img/logo.svg" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+	<script src="https://cdn.tailwindcss.com"></script>
+	<script>
+		tailwind.config = { darkMode: 'class' };
+	</script>
+	<link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen">
+
+	<header class="sticky top-0 z-50 backdrop-blur-md bg-slate-950/70 border-b border-slate-800">
+		<nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+			<a href="index.html" class="flex items-center gap-3 group">
+				<img src="img/logo.svg" alt="Kesh logo" class="w-9 h-9 transition-transform group-hover:scale-110" />
+				<span class="text-xl font-bold tracking-tight">Kesh</span>
+			</a>
+			<div class="hidden md:flex items-center gap-8 text-sm font-medium">
+				<a href="index.html" class="text-slate-300 hover:text-white transition-colors">Home</a>
+				<a href="about.html" class="text-slate-300 hover:text-white transition-colors">About</a>
+				<a href="roadmap.html" class="text-emerald-400">Roadmap</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="text-slate-300 hover:text-white transition-colors">Issues</a>
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">GitHub</a>
+			</div>
+		</nav>
+	</header>
+
+	<!-- Hero -->
+	<section class="relative overflow-hidden border-b border-slate-800">
+		<div class="absolute inset-0 hero-gradient"></div>
+		<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+			<p class="text-emerald-400 text-sm font-mono mb-3">// Roadmap</p>
+			<h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight mb-6">From foundations to Swiss VAT.</h1>
+			<p class="text-lg text-slate-300 leading-relaxed">Kesh is delivered as a sequence of <strong class="text-white">epics</strong>, each composed of small, independently reviewable stories. The release plan below tracks the path from MVP (v0.1) to the first feature-complete production release (v0.2).</p>
+			<div class="flex gap-4 mt-8 text-sm">
+				<div class="flex items-center gap-2">
+					<span class="w-3 h-3 rounded-full bg-emerald-400"></span>
+					<span class="text-slate-400">Done</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<span class="w-3 h-3 rounded-full bg-amber-400 pulse-glow"></span>
+					<span class="text-slate-400">In progress</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<span class="w-3 h-3 rounded-full bg-slate-600"></span>
+					<span class="text-slate-400">Backlog</span>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- v0.1 -->
+	<section class="border-b border-slate-800">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<div class="flex items-baseline gap-4 mb-2">
+				<h2 class="text-3xl font-bold tracking-tight">v0.1 — MVP</h2>
+				<span class="text-sm text-slate-500 font-mono">Foundation release</span>
+			</div>
+			<p class="text-slate-400 mb-10">Core accounting, contacts, invoicing, banking import. The minimum a Swiss freelancer needs to issue invoices and reconcile bank statements.</p>
+
+			<div class="relative pl-12 space-y-8">
+				<div class="timeline-line"></div>
+
+				<!-- E1 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E1 — Foundations &amp; Authentication</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Workspace bootstrap, MariaDB schema baseline, JWT authentication with refresh tokens, password hashing, login flow.</p>
+					</div>
+				</div>
+
+				<!-- E2 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E2 — Onboarding &amp; Configuration</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Company creation flow, user-to-company assignment, multi-tenant scoping (<code>company_id</code> JWT claim).</p>
+					</div>
+				</div>
+
+				<!-- E3 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E3 — Chart of Accounts &amp; Journal Entries</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Swiss chart of accounts seed, double-entry validation, journal entry CRUD, immutable audit log.</p>
+					</div>
+				</div>
+
+				<!-- E4 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E4 — Contacts &amp; Product Catalog</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Contact management (customers, suppliers), product catalog with VAT rates and payment terms.</p>
+					</div>
+				</div>
+
+				<!-- E5 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E5 — QR Bill Invoicing</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Invoice CRUD, QR Bill 2.2 PDF generation, invoice status workflow (draft → sent → paid).</p>
+					</div>
+				</div>
+
+				<!-- E6 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E6 — Quality &amp; CI/CD</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">GitHub Actions CI pipeline, Docker images on Docker Hub, pre-commit hooks, automated release tagging.</p>
+					</div>
+				</div>
+
+				<!-- E7 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E7 — Technical Debt Closure</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Multi-tenant scoping rollout, full-text search, Playwright stability fixes, security hardening (KF-002 audit).</p>
+					</div>
+				</div>
+
+				<!-- E8 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-amber-400 border-4 border-slate-950 ring-2 ring-amber-400/30 pulse-glow"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-amber-400/40">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E8 — Bank Import &amp; Reconciliation</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-amber-400/10 text-amber-300 border border-amber-400/30">In progress</span>
+						</div>
+						<p class="text-sm text-slate-400 mb-3">CAMT.053 ISO 20022 parser, CSV import (multi-bank profiles), automatic reconciliation against open invoices.</p>
+						<div class="text-xs font-mono text-slate-500 space-y-1">
+							<div>↳ 8-1a CAMT.053 parser <span class="text-emerald-400">✓ done</span></div>
+							<div>↳ 8-1b CAMT.053 persistence + UI <span class="text-emerald-400">✓ done</span></div>
+							<div>↳ 8-2 CSV import <span class="text-amber-300">in progress</span></div>
+							<div>↳ 8-3+ reconciliation <span class="text-slate-500">backlog</span></div>
+						</div>
+					</div>
+				</div>
+
+				<!-- E9 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-slate-600 border-4 border-slate-950"></div>
+					<div class="p-5 rounded-xl bg-slate-900/50 border border-slate-800">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold text-slate-300">E9 — Reports &amp; Exports</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-400 border border-slate-700">Backlog</span>
+						</div>
+						<p class="text-sm text-slate-500">Balance sheet, P&amp;L, trial balance, CSV/PDF exports.</p>
+					</div>
+				</div>
+
+				<!-- E10 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-slate-600 border-4 border-slate-950"></div>
+					<div class="p-5 rounded-xl bg-slate-900/50 border border-slate-800">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold text-slate-300">E10 — Deployment &amp; Operations</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-400 border border-slate-700">Backlog</span>
+						</div>
+						<p class="text-sm text-slate-500">Production docker-compose, backup/restore tooling, observability dashboards, security baseline.</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- v0.2 -->
+	<section class="border-b border-slate-800 bg-slate-900/30">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+			<div class="flex items-baseline gap-4 mb-2">
+				<h2 class="text-3xl font-bold tracking-tight">v0.2 — Production-ready</h2>
+				<span class="text-sm text-slate-500 font-mono">Swiss VAT &amp; payments</span>
+			</div>
+			<p class="text-slate-400 mb-10">Everything an SME needs to run a full fiscal year on Kesh: VAT computation, outgoing payments, budgets, year-end closing.</p>
+
+			<div class="grid sm:grid-cols-2 gap-4">
+				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="font-semibold mb-1">E11 — Swiss VAT</h3>
+					<p class="text-sm text-slate-400">Per-period VAT computation, official VAT report formats, multiple rates (standard, reduced, accommodation).</p>
+				</div>
+				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="font-semibold mb-1">E12 — Credits &amp; Payments (pain.001)</h3>
+					<p class="text-sm text-slate-400">Generate ISO 20022 pain.001 outgoing payment files for upload to Swiss e-banking.</p>
+				</div>
+				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="font-semibold mb-1">E13 — Budgets</h3>
+					<p class="text-sm text-slate-400">Annual budgets per account, variance reports, cash-flow forecasting.</p>
+				</div>
+				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+					<h3 class="font-semibold mb-1">E14 — Year-end Closing</h3>
+					<p class="text-sm text-slate-400">Period locking, opening balance carry-forward, closing entries automation.</p>
+				</div>
+				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800 sm:col-span-2">
+					<h3 class="font-semibold mb-1">E15 — Receipts, Payment Matching &amp; Custom Journals</h3>
+					<p class="text-sm text-slate-400">Document attachments, automated payment matching to invoices, user-definable journal types.</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Track progress -->
+	<section>
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+			<h2 class="text-2xl font-bold tracking-tight mb-3">Track progress</h2>
+			<p class="text-slate-400 mb-8">All work is tracked publicly on GitHub.</p>
+			<div class="flex flex-col sm:flex-row gap-4 justify-center">
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-emerald-500 text-slate-950 font-semibold hover:bg-emerald-400 transition-colors">Browse issues</a>
+				<a href="https://github.com/guycorbaz/kesh/pulls" target="_blank" rel="noopener" class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg border border-slate-700 hover:border-slate-500 hover:bg-slate-800/50 transition-colors text-slate-100 font-semibold">Open pull requests</a>
+			</div>
+		</div>
+	</section>
+
+	<footer class="border-t border-slate-800 bg-slate-950">
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-400">
+			<div class="flex items-center gap-3">
+				<img src="img/logo.svg" alt="" class="w-7 h-7 opacity-70" />
+				<span>Kesh — open-source Swiss accounting</span>
+			</div>
+			<div class="flex items-center gap-6">
+				<a href="https://github.com/guycorbaz/kesh" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+				<a href="https://github.com/guycorbaz/kesh/issues" target="_blank" rel="noopener" class="hover:text-white transition-colors">Issues</a>
+				<a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12" target="_blank" rel="noopener" class="hover:text-white transition-colors">EUPL 1.2</a>
+			</div>
+		</div>
+	</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- New static marketing site under `website/` (HTML5 + Tailwind CDN, no build step) covering homepage, about, roadmap, and issues.
- Auto-deployment via `.github/workflows/deploy-pages.yml` on every push to `main` that touches `website/**`.
- Visual style: dark mode primary, Inter + JetBrains Mono fonts, hero gradient + grid background, animated fade-up + pulse-glow with `prefers-reduced-motion` opt-out.

## Pages

| File | Purpose |
|------|---------|
| `index.html` | Hero + 6-card features grid + tech stack + CTA |
| `about.html` | Mission, multi-crate architecture, Swiss compliance, BMAD methodology |
| `roadmap.html` | Visual epic timeline (v0.1 done/in-progress, v0.2 backlog) — sourced from README |
| `issues.html` | 3 GitHub issue templates + label-based deep links |
| `404.html` | Branded fallback served by GitHub Pages |
| `css/style.css` | Hero gradient, animations, focus rings, reduced-motion media query |
| `img/logo.svg` | 64×64 SVG logo (emerald → blue gradient) |

## After merge — repo admin

In **Settings → Pages**:

1. Set **Source** to **GitHub Actions** (not the legacy "Deploy from a branch").
2. Wait for the first workflow run to complete — site published at `https://guycorbaz.github.io/kesh/`.

Custom domain can be added later by dropping a `CNAME` file in `website/` plus a DNS record.

## Test plan

- [x] All 5 HTML files parse cleanly (`python3 html.parser`)
- [x] Local preview with `python3 -m http.server` — every page + asset returns HTTP 200
- [x] Roadmap content matches README's epic table (E1–E15, statuses ✅/🚧/📋)
- [ ] Post-merge: GitHub Pages workflow run goes green
- [ ] Post-merge: live site loads with correct dark-mode rendering, responsive nav, working external links
- [ ] Post-merge: 404 fallback rendered for unknown paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)