### PR TITLE
fix(pages): auto-enable Pages on first workflow run

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,10 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          # Auto-enable Pages on first run if not already enabled in repo settings.
+          # Requires `pages: write` permission (set above).
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

The first run of `deploy-pages.yml` after merging #73 failed at the **Setup Pages** step:

> `Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions [...] HttpError: Not Found`

Run: https://github.com/guycorbaz/kesh/actions/runs/25435894276

## Fix

Set `enablement: true` on `actions/configure-pages@v5`. The action then **auto-enables** Pages on first run (using the `pages: write` permission already granted by the workflow). No manual repo Settings click required.

## Test plan

- [x] YAML parses (workflow file recognised by GitHub Actions)
- [ ] Post-merge: `Deploy GitHub Pages` workflow succeeds
- [ ] Post-merge: site live at `https://guycorbaz.github.io/kesh/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)