### PR TITLE
chore(test-infra): preset `with-company-no-fy` for AC #34 E2E (closes #90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "kesh-import",
  "kesh-qrbill",
  "kesh-reconciliation",
+ "kesh-report",
  "kesh-seed",
  "reqwest",
  "rust_decimal",
@@ -1737,6 +1738,7 @@ dependencies = [
  "dotenvy",
  "kesh-core",
  "kesh-import",
+ "kesh-report",
  "regex",
  "rust_decimal",
  "rust_decimal_macros",
@@ -1818,6 +1820,18 @@ dependencies = [
 [[package]]
 name = "kesh-report"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "kesh-core",
+ "kesh-db",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tracing",
+]
 
 [[package]]
 name = "kesh-seed"

--- a/crates/kesh-api/src/routes/test_endpoints.rs
+++ b/crates/kesh-api/src/routes/test_endpoints.rs
@@ -17,6 +17,8 @@
 //! - `fresh` : uniquement user `changeme/changeme` (AC #7)
 //! - `post-onboarding` / `with-company` : state complet post-onboarding (AC #8/#9)
 //! - `with-data` : `with-company` + contact + product (AC #10, pas de facture)
+//! - `with-company-no-fy` : `with-company` mais sans `fiscal_year`
+//!   (Issue #90 — Story 9-1 AC #34 garde-fou E2E « bouton Générer disabled »)
 //!
 //! **Concurrence** (code review P2) : un `tokio::sync::Mutex` statique
 //! sérialise tous les seed/reset server-side. Sans ça, deux workers
@@ -30,8 +32,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{Router, post};
 use kesh_db::test_fixtures::{
-    mark_onboarding_complete, seed_accounting_company, seed_changeme_user_only,
-    seed_contact_and_product, truncate_all,
+    mark_onboarding_complete, seed_accounting_company, seed_accounting_company_no_fy,
+    seed_changeme_user_only, seed_contact_and_product, truncate_all,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
@@ -77,6 +79,11 @@ pub enum Preset {
     /// `'CI Product'`. **Pas de facture pré-seedée** — les specs créent
     /// leurs fixtures dynamiquement.
     WithData,
+    /// Issue #90 / Story 9-1 AC #34 : variante de `WithCompany` qui **omet
+    /// le `fiscal_year`**. Garde-fou E2E pour la page `/reports` avec
+    /// company sans exercice comptable (bouton « Générer » disabled +
+    /// message i18n `reports-error-no-fiscal-year-available`).
+    WithCompanyNoFy,
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,7 +91,7 @@ pub struct SeedRequest {
     pub preset: Preset,
 }
 
-const VALID_PRESETS: &str = "fresh, post-onboarding, with-company, with-data";
+const VALID_PRESETS: &str = "fresh, post-onboarding, with-company, with-data, with-company-no-fy";
 
 /// Extracteur custom (code review AC #11) qui wrappe `Json<SeedRequest>`
 /// et intercepte les rejets serde pour produire un **400 Bad Request** avec
@@ -187,6 +194,15 @@ async fn seed_handler(
                 .await
                 .map_err(|e| AppError::Internal(format!("seed_contact_and_product: {e}")))?;
             "with-data"
+        }
+        Preset::WithCompanyNoFy => {
+            seed_accounting_company_no_fy(&state.pool)
+                .await
+                .map_err(|e| AppError::Internal(format!("seed_accounting_company_no_fy: {e}")))?;
+            mark_onboarding_complete(&state.pool)
+                .await
+                .map_err(|e| AppError::Internal(format!("mark_onboarding_complete: {e}")))?;
+            "with-company-no-fy"
         }
     };
 

--- a/crates/kesh-api/tests/test_endpoints_e2e.rs
+++ b/crates/kesh-api/tests/test_endpoints_e2e.rs
@@ -275,6 +275,57 @@ async fn seed_with_data_adds_contact_and_product_but_no_invoice(pool: MySqlPool)
     .await;
 }
 
+// --- Issue #90 / Story 9-1 AC #34 : preset `with-company-no-fy` --------------
+
+#[sqlx::test(migrator = "kesh_db::MIGRATOR")]
+async fn seed_with_company_no_fy_skips_fiscal_year(pool: MySqlPool) {
+    let app = spawn_app(pool.clone(), true).await;
+    let resp = app
+        .client
+        .post(app.url("/api/v1/_test/seed"))
+        .json(&json!({ "preset": "with-company-no-fy" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "body: {:?}", resp.text().await);
+
+    assert_row_counts(
+        &pool,
+        &[
+            ("users", 2),
+            ("companies", 1),
+            // Différence clé vs. `with-company` : aucun fiscal_year.
+            ("fiscal_years", 0),
+            ("accounts", 5),
+            ("company_invoice_settings", 1),
+            ("onboarding_state", 1),
+            ("vat_rates", 4),
+        ],
+    )
+    .await;
+
+    let admin_active: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM users WHERE username = 'admin' AND role = 'Admin' AND active = TRUE",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        admin_active, 1,
+        "admin user must be active so the Playwright test can login"
+    );
+
+    let step: i32 =
+        sqlx::query_scalar("SELECT step_completed FROM onboarding_state WHERE singleton = TRUE")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        step, 10,
+        "step_completed must be 10 so frontend onboarding gate (step >= 6) passes"
+    );
+}
+
 // --- AC #11 : preset invalide -----------------------------------------------
 
 #[sqlx::test(migrator = "kesh_db::MIGRATOR")]
@@ -297,7 +348,8 @@ async fn seed_rejects_invalid_preset(pool: MySqlPool) {
         msg.contains("fresh")
             && msg.contains("post-onboarding")
             && msg.contains("with-company")
-            && msg.contains("with-data"),
+            && msg.contains("with-data")
+            && msg.contains("with-company-no-fy"),
         "error message must list valid presets, got: {msg}"
     );
 }

--- a/crates/kesh-db/src/test_fixtures.rs
+++ b/crates/kesh-db/src/test_fixtures.rs
@@ -183,6 +183,98 @@ pub async fn seed_accounting_company(pool: &MySqlPool) -> Result<SeededCompany, 
     })
 }
 
+/// Variante de [`seed_accounting_company`] qui **omet le `fiscal_year`**.
+///
+/// Cas d'usage : tester l'AC #34 de Story 9-1 (Issue #90) — page `/reports`
+/// affiche bouton « Générer » disabled + message
+/// `reports-error-no-fiscal-year-available` quand `fiscal_years` est vide
+/// pour la company de l'utilisateur connecté. Représente le cas réaliste
+/// « company complète, fiscal_year supprimé après onboarding ».
+///
+/// Crée :
+/// - 1 `companies` : `'CI Test Company No FY'`
+/// - 2 `users` Admin : `admin/admin123` + `changeme/changeme`
+/// - **AUCUN `fiscal_years`** (différence clé vs. [`seed_accounting_company`])
+/// - 5 `accounts` (1000-4000) + `company_invoice_settings` + 4 `vat_rates`
+///
+/// Les call sites doivent appeler [`mark_onboarding_complete`] après pour
+/// que le user passe le gate onboarding du frontend (step ≥ 6 path B prod).
+pub async fn seed_accounting_company_no_fy(pool: &MySqlPool) -> Result<(), FixtureError> {
+    let company_result = sqlx::query(
+        "INSERT INTO companies (name, address, org_type, accounting_language, instance_language) \
+         VALUES ('CI Test Company No FY', 'Test Address 1\n1000 Lausanne', 'Independant', 'FR', 'FR')",
+    )
+    .execute(pool)
+    .await?;
+    let company_id = company_result.last_insert_id() as i64;
+
+    sqlx::query(
+        "INSERT INTO users (username, password_hash, role, active, company_id) VALUES (?, ?, 'Admin', TRUE, ?)",
+    )
+    .bind("admin")
+    .bind(ADMIN_PASSWORD_HASH)
+    .bind(company_id)
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO users (username, password_hash, role, active, company_id) VALUES (?, ?, 'Admin', TRUE, ?)",
+    )
+    .bind("changeme")
+    .bind(CHANGEME_PASSWORD_HASH)
+    .bind(company_id)
+    .execute(pool)
+    .await?;
+
+    let mut accounts: HashMap<&'static str, i64> = HashMap::new();
+    for (code, name, account_type) in &[
+        ("1000", "Caisse CI", "Asset"),
+        ("1100", "Banque CI", "Asset"),
+        ("2000", "Capital CI", "Liability"),
+        ("3000", "Ventes CI", "Revenue"),
+        ("4000", "Charges CI", "Expense"),
+    ] {
+        let result = sqlx::query(
+            "INSERT INTO accounts (company_id, number, name, account_type) VALUES (?, ?, ?, ?)",
+        )
+        .bind(company_id)
+        .bind(code)
+        .bind(name)
+        .bind(account_type)
+        .execute(pool)
+        .await?;
+        accounts.insert(*code, result.last_insert_id() as i64);
+    }
+
+    sqlx::query(
+        "INSERT INTO company_invoice_settings \
+         (company_id, default_receivable_account_id, default_revenue_account_id, default_sales_journal) \
+         VALUES (?, ?, ?, 'Ventes')",
+    )
+    .bind(company_id)
+    .bind(accounts["1100"])
+    .bind(accounts["3000"])
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT IGNORE INTO vat_rates (company_id, label, rate, valid_from, valid_to) \
+         VALUES \
+            (?, 'product-vat-normal',  8.10, '2024-01-01', NULL), \
+            (?, 'product-vat-special', 3.80, '2024-01-01', NULL), \
+            (?, 'product-vat-reduced', 2.60, '2024-01-01', NULL), \
+            (?, 'product-vat-exempt',  0.00, '2024-01-01', NULL)",
+    )
+    .bind(company_id)
+    .bind(company_id)
+    .bind(company_id)
+    .bind(company_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 /// Liste des tables à truncate (code review P5).
 ///
 /// Ordre : enfants (FK) → parents. `invoice_number_sequences` avant
@@ -518,6 +610,50 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(product_name, "CI Product");
+    }
+
+    /// Issue #90 — `seed_accounting_company_no_fy` doit produire company +
+    /// users + accounts + invoice settings + vat_rates mais **0** fiscal_year.
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn seed_accounting_company_no_fy_skips_fiscal_year(pool: MySqlPool) {
+        seed_accounting_company_no_fy(&pool).await.expect("seed");
+
+        let company_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM companies")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(company_count, 1, "1 company expected");
+
+        let user_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE role = 'Admin' AND active = TRUE")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(user_count, 2, "2 Admin users expected (admin + changeme)");
+
+        let fy_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM fiscal_years")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(fy_count, 0, "fiscal_years must be empty (AC #34 scenario)");
+
+        let account_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM accounts")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(account_count, 5, "5 accounts expected");
+
+        let cis_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM company_invoice_settings")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(cis_count, 1, "1 company_invoice_settings expected");
+
+        let vat_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vat_rates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(vat_count, 4, "4 vat_rates expected");
     }
 
     /// Code review P5 : garantit que `TABLES_TO_TRUNCATE` reste synchro

--- a/frontend/tests/e2e/helpers/test-state.ts
+++ b/frontend/tests/e2e/helpers/test-state.ts
@@ -25,7 +25,12 @@
 
 import { request as playwrightRequest, type APIRequestContext } from '@playwright/test';
 
-export type Preset = 'fresh' | 'post-onboarding' | 'with-company' | 'with-data';
+export type Preset =
+	| 'fresh'
+	| 'post-onboarding'
+	| 'with-company'
+	| 'with-data'
+	| 'with-company-no-fy';
 
 // Storage key constants (must match auth.svelte.ts — if keys change there, update here too)
 const STORAGE_KEY_ACCESS_TOKEN = 'kesh:auth:accessToken';

--- a/frontend/tests/e2e/reports.spec.ts
+++ b/frontend/tests/e2e/reports.spec.ts
@@ -6,11 +6,11 @@
  *   2. AC #28 (T12.1) : génération bilan via UI sur preset `with-company` (sans
  *      écritures → empty-state message attendu, mais le flow Generate→Response
  *      est vérifié end-to-end avec MariaDB up + audit best-effort)
- *   3. AC #34 (T12.4) : company sans fiscal_year → bouton Générer disabled
- *      (TODO — code review Pass 1 P8 : actuellement skippé car les presets
- *      `with-company`/`with-data` incluent tous un fiscal_year. Implémenter
- *      un preset `with-company-no-fy` côté test_endpoints.rs pour activer.)
- *   4. AC #34 : axe a11y scan zero violations (état empty + état populé)
+ *   3. AC #34 : axe a11y scan zero violations (état empty + état populé)
+ *   4. AC #34 (T12.4) : company sans fiscal_year → bouton Générer disabled
+ *      + message i18n `reports-error-no-fiscal-year-available` visible
+ *      (preset `with-company-no-fy` — Issue #90). **Exécuté en dernier** car
+ *      reseed la DB en état no-fy, incompatible avec les tests précédents.
  *
  * Pré-requis :
  *   - MariaDB up + KESH_TEST_MODE=true.
@@ -82,23 +82,6 @@ test('reports page generates balance sheet end-to-end (AC #28, T12.1)', async ({
 	await expect(emptyMsg.or(totalActifs)).toBeVisible({ timeout: 5000 });
 });
 
-test.skip('reports page disables Générer when company has no fiscal year (AC #34, T12.4)', async () => {
-	// TODO (code review Pass 1 P8 follow-up) : ce test nécessite un preset
-	// `with-company-no-fy` dans `crates/kesh-api/src/routes/test_endpoints.rs`
-	// (et `seed_accounting_company_no_fy` dans `crates/kesh-db/src/test_fixtures.rs`)
-	// qui seed company + user admin mais PAS de fiscal_year.
-	//
-	// Tracker : créer issue GitHub « test preset `with-company-no-fy` for AC #34
-	// E2E coverage » + ajouter à epic-9.md dette technique.
-	//
-	// Comportement attendu une fois le preset disponible :
-	//   await seedTestState('with-company-no-fy');
-	//   await login(page);
-	//   await page.goto('/reports');
-	//   await expect(page.getByRole('button', { name: /générer/i })).toBeDisabled();
-	//   await expect(page.getByText(/aucun exercice comptable disponible/i)).toBeVisible();
-});
-
 test('reports page has zero axe a11y violations (empty state)', async ({ page }) => {
 	await login(page);
 	await page.goto('/reports');
@@ -125,4 +108,20 @@ test('reports page has zero axe a11y violations (populated state)', async ({ pag
 		.withTags(['wcag2a', 'wcag2aa'])
 		.analyze();
 	expect(results.violations).toEqual([]);
+});
+
+// Issue #90 — AC #34 / T12.4 : ce test reseed la DB avec `with-company-no-fy`
+// et doit donc être exécuté EN DERNIER dans ce fichier. Sinon, les tests
+// suivants qui s'attendent à un `with-company` (avec fiscal_year) seedé par
+// `beforeAll` verraient un état dérivé (no-fy) et échoueraient en cascade.
+test('reports page disables Générer when company has no fiscal year (AC #34, T12.4)', async ({
+	page,
+}) => {
+	await seedTestState('with-company-no-fy');
+	await login(page);
+	await page.goto('/reports');
+	await page.waitForLoadState('networkidle');
+
+	await expect(page.getByRole('button', { name: /générer/i })).toBeDisabled();
+	await expect(page.getByText(/aucun exercice comptable disponible/i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Adds a new Playwright seed preset `with-company-no-fy` that seeds a company complete except for the `fiscal_year` row.
- Activates the previously skipped Playwright test `T12.4` covering Story 9-1 AC #34: `/reports` page must disable « Générer » + show `reports-error-no-fiscal-year-available` when the company has no fiscal year.
- Strengthens the invalid-preset E2E assertion to require the new preset in the error body.

Closes #90.

## Changes

### Backend (Rust)
- `kesh-db::test_fixtures::seed_accounting_company_no_fy` — copy of `seed_accounting_company` minus the `fiscal_year` INSERT. Seeds 1 company + 2 admin users + 5 accounts + invoice settings + 4 VAT rates.
- `kesh-api::routes::test_endpoints::Preset::WithCompanyNoFy` — new variant + handler arm calling the new fixture then `mark_onboarding_complete` so the user passes the frontend onboarding gate (step >= 6 path B).
- `VALID_PRESETS` extended to advertise the new preset in 400 error bodies.
- Tests: `seed_with_company_no_fy_skips_fiscal_year` (HTTP E2E + fixture unit) + invalid-preset assertion strengthened.

### Frontend (TypeScript / Playwright)
- `tests/e2e/helpers/test-state.ts` — `Preset` union extended.
- `tests/e2e/reports.spec.ts` — `test.skip` removed, active T12.4 appended at end of file. T12.4 reseeds the DB with `with-company-no-fy` and must therefore run last to avoid polluting the `with-company` baseline used by the other tests in this file.

### Cargo.lock
Auto-regenerated by `cargo build` — populates `kesh-report` dependency entries that were missing from main post-9-1 merge (no impact on builds, just lock file hygiene).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --test test_endpoints_e2e` — 10/10 (1 new + 9 existing)
- [x] `cargo test test_fixtures::` — 7/7 (1 new + 6 existing)
- [x] `npm run check` — 0 errors (25 warnings pre-existing)
- [x] `npm run lint-i18n-ownership` PASS
- [x] `npm run test:unit` — 227/227
- [x] `npm run build` clean
- [x] `npx playwright test reports.spec.ts` — T12.4 PASS

## Pre-existing baseline noise (not introduced)

- 20 `kesh-api::config::tests::*` fail locally on `.env` + `KESH_HOST=0.0.0.0` + `KESH_TEST_MODE` collision — documented in 9-1 memory, identical pre/post these patches.
- 2 `reports.spec.ts` a11y tests (empty + populated state) fail on `#bits-c1` bits-ui DropdownMenu app-shell `nested-interactive` violation — pre-existing on main `6495731`, frontend Svelte untouched here. Tracked separately in **#91 (KF-027)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)