### PR TITLE
ci(release): smoke test image post-build avant push Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,23 @@ permissions:
 
 jobs:
   docker:
-    name: Build & push Docker image
+    name: Build, smoke-test & push Docker image
     runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: kesh_root
+          MARIADB_DATABASE: kesh
+          MARIADB_USER: kesh
+          MARIADB_PASSWORD: kesh_dev
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
     steps:
       - uses: actions/checkout@v4
 
@@ -31,12 +46,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & push
+      - name: Build image (load to local daemon, no push yet)
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          load: true
+          push: false
           tags: |
             guycorbaz/kesh:${{ steps.version.outputs.version }}
             guycorbaz/kesh:latest
@@ -46,6 +62,85 @@ jobs:
             org.opencontainers.image.source=https://github.com/guycorbaz/kesh
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Wait for MariaDB
+        run: |
+          sudo apt-get update && sudo apt-get install -y mariadb-client
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -pkesh_root --silent; then
+              echo "MariaDB ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "MariaDB not ready after 60s"; exit 1
+
+      - name: Smoke test — run image and assert /health
+        id: smoke
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          IMAGE="guycorbaz/kesh:${VERSION}"
+
+          # Secrets bidon générés à la volée, suffisants pour passer la validation
+          # de config (jwt ≥ 32 bytes, admin password ≥ 12 chars). Container jeté
+          # à la fin du job, jamais publié.
+          JWT_SECRET="$(openssl rand -hex 32)"
+          ADMIN_PASSWORD="$(openssl rand -base64 18)"
+
+          echo "→ Starting container from $IMAGE"
+          docker run -d \
+            --name kesh-smoke \
+            --network=host \
+            -e DATABASE_URL="mysql://root:kesh_root@127.0.0.1:3306/kesh" \
+            -e KESH_HOST="0.0.0.0" \
+            -e KESH_PORT="3000" \
+            -e KESH_JWT_SECRET="$JWT_SECRET" \
+            -e KESH_ADMIN_USERNAME="admin" \
+            -e KESH_ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+            -e RUST_LOG="info" \
+            "$IMAGE"
+
+          echo "→ Waiting for /health to return 200 (timeout 60s)"
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:3000/health > /tmp/health.json 2>/dev/null; then
+              echo "→ /health OK at attempt $i"
+              cat /tmp/health.json
+              echo
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "✗ /health never returned 200"
+              echo "--- container logs ---"
+              docker logs kesh-smoke || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+          echo "→ Asserting body shape"
+          STATUS=$(jq -r '.status' /tmp/health.json)
+          DB=$(jq -r '.db' /tmp/health.json)
+          REPORTED_VERSION=$(jq -r '.version' /tmp/health.json)
+          FAIL=0
+          [ "$STATUS" = "ok" ]           || { echo "✗ status=$STATUS, want ok"; FAIL=1; }
+          [ "$DB" = "true" ]             || { echo "✗ db=$DB, want true"; FAIL=1; }
+          [ "$REPORTED_VERSION" = "$VERSION" ] \
+            || { echo "✗ version=$REPORTED_VERSION, want $VERSION"; FAIL=1; }
+          if [ $FAIL -ne 0 ]; then
+            echo "--- container logs ---"
+            docker logs kesh-smoke || true
+            exit 1
+          fi
+          echo "✓ smoke test passed: status=ok, db=true, version=$VERSION"
+
+      - name: Cleanup smoke container
+        if: always()
+        run: docker rm -f kesh-smoke 2>/dev/null || true
+
+      - name: Push image to Docker Hub
+        run: |
+          docker push guycorbaz/kesh:${{ steps.version.outputs.version }}
+          docker push guycorbaz/kesh:latest
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Ajoute un service MariaDB 10.11 au workflow `release.yml`.
- Build l'image avec `load: true, push: false` (chargement dans le daemon Docker local du runner, pas de push immédiat).
- Smoke test : démarre un container kesh-api en `--network=host`, attend que `GET /health` retourne `200` (timeout 60s), asserte `status=ok`, `db=true`, `version=<tag>`.
- Si le smoke test échoue : logs du container dumpés, image **jamais pushée vers Docker Hub**, GitHub Release **non créée**. Fail-safe contre une release cassée.
- Cleanup du container avec `if: always()`.

Implémente l'amélioration parallèle `release.yml++` listée dans `_bmad-output/planning-artifacts/epic-10.md` (critère d'arrêt Epic 10).

## Test plan

- [ ] Merger la PR.
- [ ] Tagger `v0.1.0-rc1` annoté et le pusher → workflow `Release` se déclenche.
- [ ] Vérifier sur le run GitHub Actions :
  - service MariaDB démarre (step "Wait for MariaDB" passe).
  - build image en local OK (step "Build image (load to local daemon, no push yet)").
  - step "Smoke test" passe avec `✓ smoke test passed: status=ok, db=true, version=0.1.0-rc1`.
  - step "Push image to Docker Hub" pousse les tags `guycorbaz/kesh:0.1.0-rc1` et `guycorbaz/kesh:latest`.
  - GitHub Release `v0.1.0-rc1` créée avec release notes auto-générées.
- [ ] Vérifier sur Docker Hub que l'image `guycorbaz/kesh:0.1.0-rc1` est bien visible et taillable.
- [ ] (Optionnel) `docker pull guycorbaz/kesh:0.1.0-rc1` + run local pour double-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)