### PR TITLE
ci(release): smoke test compare base version (strip RC suffix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,17 +121,23 @@ jobs:
           STATUS=$(jq -r '.status' /tmp/health.json)
           DB=$(jq -r '.db' /tmp/health.json)
           REPORTED_VERSION=$(jq -r '.version' /tmp/health.json)
+          # Le binaire renvoie `env!("CARGO_PKG_VERSION")` (= Cargo.toml). Pour un
+          # tag pré-release `vX.Y.Z-rcN`, Cargo.toml reste figé à `X.Y.Z` (convention
+          # SemVer). On compare donc la base du tag (suffixe strip) à la version
+          # reportée. Pour un tag final `vX.Y.Z` les deux valent X.Y.Z, assertion
+          # équivalente.
+          BASE_VERSION="${VERSION%%-*}"
           FAIL=0
           [ "$STATUS" = "ok" ]           || { echo "✗ status=$STATUS, want ok"; FAIL=1; }
           [ "$DB" = "true" ]             || { echo "✗ db=$DB, want true"; FAIL=1; }
-          [ "$REPORTED_VERSION" = "$VERSION" ] \
-            || { echo "✗ version=$REPORTED_VERSION, want $VERSION"; FAIL=1; }
+          [ "$REPORTED_VERSION" = "$BASE_VERSION" ] \
+            || { echo "✗ version=$REPORTED_VERSION, want $BASE_VERSION (base of tag $VERSION)"; FAIL=1; }
           if [ $FAIL -ne 0 ]; then
             echo "--- container logs ---"
             docker logs kesh-smoke || true
             exit 1
           fi
-          echo "✓ smoke test passed: status=ok, db=true, version=$VERSION"
+          echo "✓ smoke test passed: status=ok, db=true, version=$REPORTED_VERSION (tag $VERSION)"
 
       - name: Cleanup smoke container
         if: always()


### PR DESCRIPTION
## Summary

Fix de l'assertion `version` du smoke test (`release.yml`) qui faisait échouer le run release sur `v0.1.0-rc1` :

- Le binaire renvoie `env!("CARGO_PKG_VERSION")` = `Cargo.toml` version (= `0.1.0`).
- Le tag est `v0.1.0-rc1` (convention SemVer pré-release — `Cargo.toml` reste figé à la base).
- L'assertion comparait au tag complet → divergence systématique sur tout RC.

Désormais : on strip le suffixe (`-rc1`, `-betaN`, etc.) du tag avant comparaison. Pour un tag final `vX.Y.Z`, l'assertion reste équivalente.

## Contexte

Run release v0.1.0-rc1 échoué (https://github.com/guycorbaz/kesh/actions/runs/26504928490) sur cette seule assertion. Tout le reste OK :
- Build image ✓
- MariaDB ready ✓
- Container démarre, migrations appliquées ✓
- `/health` répond 200 avec `{"db":true,"status":"ok","version":"0.1.0"}` ✓

Fail-safe a fonctionné : image **non pushée** vers Docker Hub, GitHub Release **non créée**.

## Test plan

- [ ] Merger cette PR.
- [ ] Push d'un nouveau tag (`v0.1.0-rc2` ou re-tag `v0.1.0-rc1` après deletion) → release workflow doit converger jusqu'au push Docker Hub + GitHub Release.
- [ ] Vérifier que l'image `guycorbaz/kesh:0.1.0-rcN` est visible sur Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)