### PR TITLE
docs(v0.1.0): sync README + CHANGELOG + website pour release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Aucun changement post-v0.1.0 pour le moment.
 
 ---
 
-## [0.1.0] — À paraître
+## [0.1.0] — 2026-05-27
 
 Première version publique de Kesh. Cette release fournit un système comptable complet et conforme au Code des obligations suisse (Art. 957a et suivants) ainsi qu'à l'Ordonnance OLICo (RS 221.431), prêt pour un usage productif chez un indépendant, une PME ou un fiduciaire mono-poste.
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ Le projet suit une approche **BMAD** (Breakthrough Method of Agile AI-driven Dev
 
 | Version | Epics | Statut |
 |---------|-------|--------|
-| v0.1 | E1 Fondations & Authentification, E2 Onboarding & Configuration, E3 Plan comptable & Écritures, E4 Carnet d'adresses & Catalogue, E5 Facturation QR Bill, E6 Qualité & CI/CD, E7 Technical Debt Closure, E8 Import bancaire & Réconciliation, E9 Rapports & Exports, E9.5 Technical Debt Closure | ✅ Done |
-| v0.1 | E10 Déploiement & Opérations | 🚧 En cours |
+| v0.1 | E1 Fondations & Authentification, E2 Onboarding & Configuration, E3 Plan comptable & Écritures, E4 Carnet d'adresses & Catalogue, E5 Facturation QR Bill, E6 Qualité & CI/CD, E7 Technical Debt Closure, E8 Import bancaire & Réconciliation, E9 Rapports & Exports, E9.5 Technical Debt Closure, E10 Déploiement & Opérations | ✅ Done |
 | v0.2 | E11 TVA Suisse, E12 Avoirs & Paiements (pain.001), E13 Budgets, E14 Clôture d'exercice, E15 Justificatifs, Lettrage & Compléments (inc. journaux personnalisables) | 📋 Backlog |
 
 Détails : [PRD complet](_bmad-output/planning-artifacts/prd.md).

--- a/website/index.html
+++ b/website/index.html
@@ -66,8 +66,8 @@
 		<div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32 lg:py-40">
 			<div class="max-w-4xl mx-auto text-center">
 				<div class="animate-fade-up inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 text-sm font-medium mb-6">
-					<span class="w-2 h-2 rounded-full bg-emerald-400 pulse-glow"></span>
-					v0.1 in active development
+					<span class="w-2 h-2 rounded-full bg-emerald-400"></span>
+					v0.1.0 released — Docker image available
 				</div>
 				<h1 class="animate-fade-up delay-1 text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6">
 					Open-source <span class="bg-gradient-to-r from-emerald-400 via-blue-400 to-emerald-500 bg-clip-text text-transparent">Swiss accounting</span> &amp; invoicing

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -156,45 +156,57 @@
 
 				<!-- E8 -->
 				<div class="relative">
-					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-amber-400 border-4 border-slate-950 ring-2 ring-amber-400/30 pulse-glow"></div>
-					<div class="p-5 rounded-xl bg-slate-900 border border-amber-400/40">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
 						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
 							<h3 class="text-lg font-semibold">E8 — Bank Import &amp; Reconciliation</h3>
-							<span class="text-xs font-mono px-2 py-0.5 rounded bg-amber-400/10 text-amber-300 border border-amber-400/30">In progress</span>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
 						</div>
-						<p class="text-sm text-slate-400 mb-3">CAMT.053 ISO 20022 parser, CSV import (multi-bank profiles), automatic reconciliation against open invoices.</p>
+						<p class="text-sm text-slate-400 mb-3">CAMT.053 ISO 20022 parser, CSV import (multi-bank profiles), automatic reconciliation against open invoices, manual reconciliation with transaction splitting and assignment rules engine.</p>
 						<div class="text-xs font-mono text-slate-500 space-y-1">
 							<div>↳ 8-1a CAMT.053 parser <span class="text-emerald-400">✓ done</span></div>
 							<div>↳ 8-1b CAMT.053 persistence + UI <span class="text-emerald-400">✓ done</span></div>
 							<div>↳ 8-2 CSV import (multi-bank profiles) <span class="text-emerald-400">✓ done</span></div>
 							<div>↳ 8-3 duplicate detection + partial reject <span class="text-emerald-400">✓ done</span></div>
 							<div>↳ 8-4 automatic reconciliation + scoring <span class="text-emerald-400">✓ done</span></div>
-							<div>↳ 8-5 manual reconciliation + assignment rules <span class="text-slate-500">backlog</span></div>
+							<div>↳ 8-5 manual reconciliation + assignment rules <span class="text-emerald-400">✓ done</span></div>
 						</div>
 					</div>
 				</div>
 
 				<!-- E9 -->
 				<div class="relative">
-					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-slate-600 border-4 border-slate-950"></div>
-					<div class="p-5 rounded-xl bg-slate-900/50 border border-slate-800">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
 						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
-							<h3 class="text-lg font-semibold text-slate-300">E9 — Reports &amp; Exports</h3>
-							<span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-400 border border-slate-700">Backlog</span>
+							<h3 class="text-lg font-semibold">E9 — Reports &amp; Exports</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
 						</div>
-						<p class="text-sm text-slate-500">Balance sheet, P&amp;L, trial balance, CSV/PDF exports.</p>
+						<p class="text-sm text-slate-400">Balance sheet, P&amp;L, trial balance, CSV/PDF exports, global ZIP export (sovereignty).</p>
+					</div>
+				</div>
+
+				<!-- E9.5 -->
+				<div class="relative">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
+						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
+							<h3 class="text-lg font-semibold">E9.5 — Technical Debt Closure</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+						</div>
+						<p class="text-sm text-slate-400">Zero-carry-forward debt sweep before v0.1 release: closed 6 KFs, codified review &amp; commit rules, Swiss CO 958f research.</p>
 					</div>
 				</div>
 
 				<!-- E10 -->
 				<div class="relative">
-					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-slate-600 border-4 border-slate-950"></div>
-					<div class="p-5 rounded-xl bg-slate-900/50 border border-slate-800">
+					<div class="absolute -left-[2.6rem] top-1.5 w-5 h-5 rounded-full bg-emerald-500 border-4 border-slate-950 ring-2 ring-emerald-500/30"></div>
+					<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30">
 						<div class="flex items-center justify-between mb-2 flex-wrap gap-2">
-							<h3 class="text-lg font-semibold text-slate-300">E10 — Deployment &amp; Operations</h3>
-							<span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-400 border border-slate-700">Backlog</span>
+							<h3 class="text-lg font-semibold">E10 — Deployment &amp; Operations</h3>
+							<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
 						</div>
-						<p class="text-sm text-slate-500">Production docker-compose, backup/restore tooling, observability dashboards, security baseline.</p>
+						<p class="text-sm text-slate-400">Production hardening (Docker, env vars, log rotation), migrations idempotence with downgrade protection, frontend resilience when DB unreachable, Synology DSM install manual + native backup, httpOnly auth cookies.</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

Met à jour les supports utilisateur pour refléter l'état effectif du projet avant le tag `v0.1.0` final :

- **README.md** : Epic 10 Déploiement & Opérations fusionné dans la ligne v0.1 ✅ Done (était ligne séparée 🚧 En cours).
- **CHANGELOG.md** : date release `[0.1.0] — 2026-05-27` (était « À paraître »).
- **website/index.html** : headline « v0.1.0 released — Docker image available » (était « v0.1 in active development » avec pulse-glow animé).
- **website/roadmap.html** :
  - E8 Bank Import : In progress → Done + 8-5 backlog → done dans la liste des sous-stories.
  - E9 Reports & Exports : Backlog → Done, description enrichie (CSV/PDF exports + global ZIP sovereignty).
  - **E9.5 Technical Debt Closure** : ajouté (manquait — Done).
  - E10 Deployment & Operations : Backlog → Done, description enrichie des 5 stories livrées.

## Pré-flight v0.1.0

Cohérent avec la règle CLAUDE.md « synchroniser TOUTES les docs avant tout push / création de release ». Une fois cette PR mergée + CI verte :

1. Tag annoté `v0.1.0` final
2. Workflow Release pousse `gcorbaz/kesh:0.1.0` + `:latest` sur Docker Hub
3. GitHub Release `v0.1.0` créée avec release notes auto-générées

L'image `gcorbaz/kesh:0.1.0-rc3` validée hier sert de base — `v0.1.0` final n'introduit aucun changement de code par rapport à RC3 (juste docs).

## Test plan

- [ ] CI verte (Backend Rust, Frontend Svelte, Docker build sanity)
- [ ] Merger la PR
- [ ] Tag `v0.1.0` + push → workflow Release converge vers Docker Hub + GitHub Release
- [ ] Vérifier https://hub.docker.com/r/gcorbaz/kesh/tags : `0.1.0` et `latest` (latest re-pointé sur 0.1.0)
- [ ] Vérifier site GitHub Pages republished avec la nouvelle roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)