### PR TITLE
chore(release): prepare v0.1.1 — date + roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
-## [0.1.1] — Non publié
+## [0.1.1] — 2026-05-29
 
-Hotfix post-déploiement v0.1.0 : corrections et améliorations opérationnelles découvertes lors du premier déploiement en production sur NAS Synology.
+Hotfix post-déploiement v0.1.0 : corrections et améliorations opérationnelles découvertes lors du premier déploiement en production sur NAS Synology. Cette release embarque les **2 stories critiques** de l'épic hotfix (logs fichier + déblocage du premier démarrage). Les stories restantes de l'épic (break-glass admin reset, port 80 par défaut) sont reportées à une release ultérieure.
 
 ### Ajouts
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Le projet suit une approche **BMAD** (Breakthrough Method of Agile AI-driven Dev
 | Version | Epics | Statut |
 |---------|-------|--------|
 | v0.1 | E1 Fondations & Authentification, E2 Onboarding & Configuration, E3 Plan comptable & Écritures, E4 Carnet d'adresses & Catalogue, E5 Facturation QR Bill, E6 Qualité & CI/CD, E7 Technical Debt Closure, E8 Import bancaire & Réconciliation, E9 Rapports & Exports, E9.5 Technical Debt Closure, E10 Déploiement & Opérations | ✅ Done |
-| v0.1.1 (hotfix) | Logs fichier avec rotation, fix onboarding catch-22 (fresh install), break-glass admin reset, port 80 par défaut | 🚧 En cours |
+| v0.1.1 (hotfix) | Logs fichier avec rotation, fix onboarding catch-22 (fresh install) | ✅ Done |
+| v0.1.x (hotfix, à venir) | Break-glass admin reset, port 80 par défaut | 📋 Backlog |
 | v0.2 | E11 TVA Suisse, E12 Avoirs & Paiements (pain.001), E13 Budgets, E14 Clôture d'exercice, E15 Justificatifs, Lettrage & Compléments (inc. journaux personnalisables) | 📋 Backlog |
 
 Détails : [PRD complet](_bmad-output/planning-artifacts/prd.md).


### PR DESCRIPTION
## Summary

Préparation tag v0.1.1 (hotfix post-déploiement v0.1.0) :
- CHANGELOG `[0.1.1]` : « Non publié » → **2026-05-29**, note de scope (2 stories critiques sur 4 prévues).
- README roadmap : v0.1.1 ✅ Done (logs + catch-22) ; nouvelle ligne v0.1.x backlog (break-glass + port 80).

Pas de code modifié. Tag v0.1.1 sera créé sur le merge de cette PR pour déclencher `release.yml` (build + push Docker Hub `gcorbaz/kesh:0.1.1` + `latest`).

## Test plan

- [x] CHANGELOG conforme [Keep a Changelog]
- [x] README cohérent avec le scope effectif livré
- [ ] CI verte (sanity, pas de code changé)
- [ ] Tag v0.1.1 post-merge → release.yml → image Docker publiée

🤖 Generated with [Claude Code](https://claude.com/claude-code)