### PR TITLE
chore(release): prepare v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
-## [0.1.4] — Non publié
+## [0.1.4] — 2026-06-01
 
 Hotfix UX consolidé suite à dogfooding live sur prod NAS Synology v0.1.3 : CRUD complet des comptes bancaires post-onboarding (le seul endpoint existant `POST /api/v1/onboarding/bank-account` refusait les appels post-onboarding), restructuration de la sidebar avec groupes collapsibles, ajout des 4 pages orphelines précédemment accessibles uniquement via URL directe, widget homepage avec soldes calculés.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "argon2",
  "axum",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "kesh-import",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-db"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "dotenvy",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-i18n"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "fluent-bundle",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-import"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2030,11 +2030,11 @@ dependencies = [
 
 [[package]]
 name = "kesh-payment"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "kesh-qrbill"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "printpdf",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-reconciliation"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "kesh-db",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-report"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-seed"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Le projet suit une approche **BMAD** (Breakthrough Method of Agile AI-driven Dev
 | v0.1.1 (hotfix) | Logs fichier avec rotation, fix onboarding catch-22 (fresh install) | ✅ Done |
 | v0.1.2 (hotfix) | Port 80 par défaut, onboarding self-service unifié (admin créé via UI au 1er boot, recovery break-glass via `.env`) | ✅ Done |
 | v0.1.3 (hotfix) | Déblocage déploiements LAN HTTP-only (`KESH_COOKIE_SECURE=false` pour LAN privé `*.home.arpa` derrière Traefik sans HTTPS) | ✅ Done |
-| v0.1.4 (hotfix) | CRUD `bank_accounts` post-onboarding + sidebar collapsible + restructuration UX (pages orphelines, widget solde homepage) | 🚧 En cours |
+| v0.1.4 (hotfix) | CRUD `bank_accounts` post-onboarding + sidebar collapsible + restructuration UX (pages orphelines, widget solde homepage) | ✅ Done |
 | v0.2 | E11 TVA Suisse, E12 Avoirs & Paiements (pain.001), E13 Budgets, E14 Clôture d'exercice, E15 Justificatifs, Lettrage & Compléments (inc. journaux personnalisables) | 📋 Backlog |
 
 Détails : [PRD complet](_bmad-output/planning-artifacts/prd.md).

--- a/crates/kesh-api/Cargo.toml
+++ b/crates/kesh-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-api"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-core/Cargo.toml
+++ b/crates/kesh-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-core"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-db/Cargo.toml
+++ b/crates/kesh-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-db"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-i18n/Cargo.toml
+++ b/crates/kesh-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-i18n"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-import/Cargo.toml
+++ b/crates/kesh-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-import"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 description = "Parseurs CAMT.053 ISO 20022 et CSV multi-encodage pour relevés bancaires"

--- a/crates/kesh-payment/Cargo.toml
+++ b/crates/kesh-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-payment"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-qrbill/Cargo.toml
+++ b/crates/kesh-qrbill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-qrbill"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 description = "Swiss QR Bill SIX 2.2 payload builder and PDF generator (standalone, publishable)"

--- a/crates/kesh-reconciliation/Cargo.toml
+++ b/crates/kesh-reconciliation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-reconciliation"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-report/Cargo.toml
+++ b/crates/kesh-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-report"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-seed/Cargo.toml
+++ b/crates/kesh-seed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-seed"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
## Summary

Préparation release v0.1.4 (pattern v0.1.3 release flow via `scripts/prepare-release.sh`) :

- 10 crates `Cargo.toml` bumpés `0.1.3 → 0.1.4`
- `Cargo.lock` régénéré (kesh-* deps cohérentes)
- `CHANGELOG.md` section `[0.1.4]` passe `Non publié` → `2026-06-01`
- `README.md` feuille de route : v0.1.4 (hotfix) `🚧 En cours` → `✅ Done`

Cette PR ne change AUCUN code — uniquement métadonnées de version + dates.

## Test plan

- [x] `scripts/prepare-release.sh 0.1.4` exécuté sans erreur
- [x] CI green (auto sur push)
- [ ] Post-merge : tag `v0.1.4` annoté + push → déclenche `release.yml` → publish `gcorbaz/kesh:0.1.4` + `latest` sur Docker Hub
- [ ] Dogfooding NAS Synology après release

🤖 Generated with [Claude Code](https://claude.com/claude-code)