### PR TITLE
fix(dogfooding v0.1.4): page blanche HTTP LAN (#145) + scroll Select (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
+## [Non publié]
+
+Correctifs issus du dogfooding live sur prod NAS Synology v0.1.4 (déploiement HTTP réseau local).
+
+### Fixed
+
+- **Pages « Facturer » et « Échéancier » blanches en déploiement HTTP** (#145) — sur une installation servie en HTTP sur le réseau local (sans HTTPS), ces deux pages s'affichaient entièrement vides. Cause : une fonctionnalité du navigateur (`crypto.randomUUID`) n'est disponible qu'en contexte sécurisé (HTTPS ou `localhost`) et provoquait une erreur bloquant le rendu. Les pages se chargent désormais correctement quel que soit le mode de déploiement.
+- **Liste déroulante « Compte parent » non défilable** (#143) — lors de la création d'un compte dans le plan comptable, la liste des comptes parents n'était pas défilable quand elle dépassait la hauteur de l'écran (cas d'un plan comptable suisse complet), rendant les comptes du bas inaccessibles. La liste est désormais plafonnée en hauteur et défilable. Le correctif s'applique à toutes les listes déroulantes longues de l'application.
+
+---
+
 ## [0.1.4] — 2026-06-01
 
 Hotfix UX consolidé suite à dogfooding live sur prod NAS Synology v0.1.3 : CRUD complet des comptes bancaires post-onboarding (le seul endpoint existant `POST /api/v1/onboarding/bank-account` refusait les appels post-onboarding), restructuration de la sidebar avec groupes collapsibles, ajout des 4 pages orphelines précédemment accessibles uniquement via URL directe, widget homepage avec soldes calculés.

--- a/frontend/src/lib/components/invoices/ContactPicker.svelte
+++ b/frontend/src/lib/components/invoices/ContactPicker.svelte
@@ -15,13 +15,14 @@
 	};
 	let { selected, onSelect, placeholder = 'Rechercher un contact…' }: Props = $props();
 
-	// ID unique par instance — généré au mount côté client pour garantir
-	// la stabilité hydration (évite qu'un rendu SSR produise une valeur
-	// différente du client). Suit le pattern combobox ARIA : les IDs doivent
-	// exister au premier render, donc on initialise immédiatement avec
-	// `crypto.randomUUID` (supporté par tous les runtimes cibles de Kesh :
-	// navigateurs modernes + Node 18+ pour SSR).
-	const instanceId = crypto.randomUUID().slice(0, 8);
+	// ID unique par instance pour le pattern combobox ARIA (les IDs doivent
+	// exister au premier render). On utilise le rune `$props.id()` de Svelte 5,
+	// unique par instance et stable en hydration. NE PAS utiliser
+	// `crypto.randomUUID()` : cette API n'est disponible qu'en contexte
+	// sécurisé (HTTPS ou http://localhost) et lève `TypeError: crypto.randomUUID
+	// is not a function` sur un déploiement HTTP LAN (cf. NAS Synology), ce qui
+	// crashe au rendu toute page consommant ce composant (#145).
+	const instanceId = $props.id();
 	const listboxId = `contact-picker-list-${instanceId}`;
 	const optionId = (contactId: number) => `contact-picker-opt-${instanceId}-${contactId}`;
 

--- a/frontend/src/lib/components/ui/select/select-content.svelte
+++ b/frontend/src/lib/components/ui/select/select-content.svelte
@@ -27,7 +27,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 overflow-x-hidden overflow-y-auto",
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--bits-select-content-available-height) overflow-x-hidden overflow-y-auto",
 			className
 		)}
 		{...restProps}


### PR DESCRIPTION
Deux bugs frontend remontés en dogfooding live sur prod NAS Synology (déploiement **HTTP LAN**, image `gcorbaz/kesh:0.1.4`).

## #145 — « Facturer » / « Échéancier » page blanche

`ContactPicker.svelte` appelait `crypto.randomUUID()`, API disponible **uniquement en contexte sécurisé** (HTTPS ou `http://localhost`). Sur un déploiement HTTP réseau local elle est `undefined` → `TypeError: crypto.randomUUID is not a function` levé **au rendu** → toute page consommant `ContactPicker` crashe en blanc (`/invoices` et `/invoices/due-dates`).

Confirmé par le log console Firefox de l'utilisateur sur le NAS. Reproduisible uniquement hors `localhost` → passait inaperçu en dev.

**Fix** : `crypto.randomUUID().slice(0,8)` → `$props.id()` (rune Svelte 5, déjà utilisé par bits-ui, stable hydration, indépendant du contexte sécurisé). `instanceId` ne servait qu'à dériver des IDs DOM ARIA — aucun besoin de cryptographie. Audit de tout `src/` : c'était le seul appel secure-context du runtime.

## #143 — Scroll impossible dans le Select des comptes parents

`Select.Content` avait `overflow-y-auto` mais **aucun `max-height`** → sans plafond le scroll ne se déclenche jamais, la liste longue (plan comptable suisse complet) déborde de l'écran, options du bas inaccessibles.

**Fix** : ajout de `max-h-(--bits-select-content-available-height)` (var exposée par bits-ui v2 comme alias de l'`availableHeight` du middleware `size` de Floating UI). Composant partagé → corrige **tous** les Select à liste longue.

## Vérifications (Test Locally First — frontend)

- ✅ `npm run check` (0 erreur)
- ✅ `npm run lint-i18n-ownership`
- ✅ `npm run test:unit` (267 tests)
- ✅ `npm run build`

E2E non lancé localement : DB de test dans l'état sale du #140 (fiscal_year fermé) — produirait du bruit non lié. Changements à faible risque E2E (1 classe CSS + swap d'ID).

## Notes

- Candidate **hotfix v0.1.5** (prod cassée). CHANGELOG section `[Non publié]` ajoutée ; bump version/date au release-prep.
- Aucune migration, aucun changement backend.

Closes #143
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)