### PR TITLE
fix(dogfooding v0.1.5): détail écriture comptable (#148) + UX facture (#149, #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
+## [Non publié]
+
+Correctifs et améliorations issus du dogfooding live de la facturation sur prod NAS Synology v0.1.5.
+
+### Fixed
+
+- **« Voir l'écriture comptable » → page 404** (#148) : sur une facture validée, le bouton menait à une route inexistante. Ajout de la **page détail d'une écriture comptable** (`/journal-entries/{id}`, affichage des lignes débit/crédit + comptes + totaux) et de l'endpoint backend `GET /api/v1/journal-entries/{id}` (scopé société, 404 anti-énumération cross-tenant).
+
+### Changed
+
+- **Facture — placement des boutons d'ajout de ligne** (#149) : « Ligne libre » et « Depuis catalogue » sont désormais placés **sous le tableau des lignes** (au lieu de l'en-tête) pour un flux d'ajout plus naturel.
+- **Facture — bouton d'impression** (#150) : « Télécharger PDF » renommé **« Imprimer / Télécharger PDF »** avec une icône imprimante, pour la découvrabilité (la fonction existait déjà mais n'était pas identifiée comme l'impression).
+
+---
+
 ## [0.1.5] — 2026-06-03
 
 Correctifs issus du dogfooding live sur prod NAS Synology v0.1.4 (déploiement HTTP réseau local).

--- a/crates/kesh-api/src/lib.rs
+++ b/crates/kesh-api/src/lib.rs
@@ -281,6 +281,12 @@ pub fn build_router(state: AppState, static_dir: String) -> Router {
             "/api/v1/journal-entries",
             get(routes::journal_entries::list_journal_entries),
         )
+        // Détail d'une écriture (lecture, tout rôle authentifié — symétrique
+        // de la liste ci-dessus ; mutations PUT/DELETE en comptable_routes).
+        .route(
+            "/api/v1/journal-entries/{id}",
+            get(routes::journal_entries::get_journal_entry),
+        )
         // Story 4.1 : lecture carnet d'adresses (tout rôle authentifié)
         .route("/api/v1/contacts", get(routes::contacts::list_contacts))
         .route("/api/v1/contacts/{id}", get(routes::contacts::get_contact))

--- a/crates/kesh-api/src/routes/journal_entries.rs
+++ b/crates/kesh-api/src/routes/journal_entries.rs
@@ -364,6 +364,27 @@ const MAX_LINES_PER_ENTRY: usize = 500;
 /// Longueur maximale du libellé (alignée sur la colonne `description VARCHAR(500)`).
 const MAX_DESCRIPTION_LEN: usize = 500;
 
+/// GET /api/v1/journal-entries/{id} — détail d'une écriture (lignes incluses),
+/// scopée à la company courante.
+///
+/// **P10 defense in depth** : le scoping `company_id` est délégué à
+/// [`journal_entries::find_by_id`] (anti-énumération cross-tenant KF-002).
+/// Une écriture inexistante OU appartenant à une autre company retourne
+/// `404 NOT_FOUND`, jamais `403` (pas de fuite d'existence).
+pub async fn get_journal_entry(
+    State(state): State<AppState>,
+    Extension(current_user): Extension<CurrentUser>,
+    Path(id): Path<i64>,
+) -> Result<Json<JournalEntryResponse>, AppError> {
+    let company = get_company_for(&current_user, &state.pool).await?;
+
+    let entry = journal_entries::find_by_id(&state.pool, company.id, id)
+        .await?
+        .ok_or(AppError::Database(kesh_db::errors::DbError::NotFound))?;
+
+    Ok(Json(JournalEntryResponse::from(entry)))
+}
+
 /// POST /api/v1/journal-entries — crée une écriture en partie double.
 pub async fn create_journal_entry(
     State(state): State<AppState>,

--- a/crates/kesh-api/tests/idor_multi_tenant_e2e.rs
+++ b/crates/kesh-api/tests/idor_multi_tenant_e2e.rs
@@ -308,6 +308,92 @@ async fn idor_contacts_cross_company_returns_404(pool: MySqlPool) {
 }
 
 #[sqlx::test(migrator = "kesh_db::MIGRATOR")]
+async fn idor_journal_entries_cross_company_returns_404(pool: MySqlPool) {
+    truncate_all(&pool).await.expect("truncate");
+
+    // Setup: two companies with users
+    let (company_a_id, accounts_a) = create_seeded_company(&pool).await;
+    let (company_b_id, _accounts_b) = create_seeded_company(&pool).await;
+
+    let _user_a_id = create_company_user(&pool, company_a_id, "alice", "password123").await;
+    let _user_b_id = create_company_user(&pool, company_b_id, "bob", "password123").await;
+
+    let app = spawn_app(pool.clone()).await;
+    let token_a = login(&app, "alice", "password123").await;
+    let token_b = login(&app, "bob", "password123").await;
+
+    // Create a balanced journal entry in company A (debit 1000 / credit 3000).
+    let create_resp = app
+        .client
+        .post(app.url("/api/v1/journal-entries"))
+        .header("Authorization", format!("Bearer {}", token_a))
+        .json(&json!({
+            "entryDate": "2025-06-15",
+            "journal": "Ventes",
+            "description": "Écriture IDOR test",
+            "lines": [
+                { "accountId": accounts_a["1000"], "debit": "100.00", "credit": "0.00" },
+                { "accountId": accounts_a["3000"], "debit": "0.00", "credit": "100.00" }
+            ]
+        }))
+        .send()
+        .await
+        .expect("create should succeed");
+
+    assert_eq!(create_resp.status(), 201);
+    let entry_data: serde_json::Value = create_resp.json().await.expect("json body");
+    let entry_a_id = entry_data["id"].as_i64().expect("id present");
+
+    // Attempt to access entry A as user B (cross-company) → 404 anti-énumération.
+    let get_resp = app
+        .client
+        .get(app.url(&format!("/api/v1/journal-entries/{}", entry_a_id)))
+        .header("Authorization", format!("Bearer {}", token_b))
+        .send()
+        .await
+        .expect("get should succeed");
+
+    assert_eq!(
+        get_resp.status(),
+        404,
+        "User B cannot access journal entry from company A"
+    );
+
+    // Non-existent entry id → 404 (jamais 200 vide).
+    let missing_resp = app
+        .client
+        .get(app.url("/api/v1/journal-entries/99999999"))
+        .header("Authorization", format!("Bearer {}", token_a))
+        .send()
+        .await
+        .expect("get should succeed");
+
+    assert_eq!(
+        missing_resp.status(),
+        404,
+        "Non-existent journal entry returns 404"
+    );
+
+    // User A can access own entry → 200 avec ses lignes.
+    let own_access = app
+        .client
+        .get(app.url(&format!("/api/v1/journal-entries/{}", entry_a_id)))
+        .header("Authorization", format!("Bearer {}", token_a))
+        .send()
+        .await
+        .expect("get should succeed");
+
+    assert_eq!(own_access.status(), 200, "User A can access own entry");
+    let body: serde_json::Value = own_access.json().await.expect("json body");
+    assert_eq!(body["id"].as_i64(), Some(entry_a_id));
+    assert_eq!(
+        body["lines"].as_array().map(|a| a.len()),
+        Some(2),
+        "le détail inclut les 2 lignes"
+    );
+}
+
+#[sqlx::test(migrator = "kesh_db::MIGRATOR")]
 async fn idor_products_cross_company_returns_404(pool: MySqlPool) {
     truncate_all(&pool).await.expect("truncate");
 

--- a/frontend/src/lib/components/invoices/InvoiceForm.svelte
+++ b/frontend/src/lib/components/invoices/InvoiceForm.svelte
@@ -456,19 +456,7 @@
 	</div>
 
 	<div>
-		<div class="mb-2 flex items-center justify-between">
-			<h3 class="text-lg font-semibold">Lignes</h3>
-			<div class="flex gap-2">
-				<Button type="button" variant="outline" onclick={addFreeLine}>
-					<Plus class="h-4 w-4" aria-hidden="true" />
-					Ligne libre
-				</Button>
-				<Button type="button" variant="outline" onclick={() => (productPickerOpen = true)}>
-					<Package class="h-4 w-4" aria-hidden="true" />
-					Depuis catalogue
-				</Button>
-			</div>
-		</div>
+		<h3 class="mb-2 text-lg font-semibold">Lignes</h3>
 
 		<table class="w-full border-collapse text-sm" data-testid="invoice-lines-table">
 			<thead>
@@ -534,6 +522,17 @@
 				</tr>
 			</tfoot>
 		</table>
+
+		<div class="mt-3 flex gap-2">
+			<Button type="button" variant="outline" onclick={addFreeLine}>
+				<Plus class="h-4 w-4" aria-hidden="true" />
+				Ligne libre
+			</Button>
+			<Button type="button" variant="outline" onclick={() => (productPickerOpen = true)}>
+				<Package class="h-4 w-4" aria-hidden="true" />
+				Depuis catalogue
+			</Button>
+		</div>
 	</div>
 
 	<div class="flex justify-end gap-2">

--- a/frontend/src/lib/features/journal-entries/journal-entries.api.ts
+++ b/frontend/src/lib/features/journal-entries/journal-entries.api.ts
@@ -28,6 +28,14 @@ export async function fetchJournalEntries(
 	return apiClient.get<ListResponse<JournalEntryResponse>>(url);
 }
 
+/**
+ * Récupère le détail d'une écriture (lignes incluses) par son id.
+ * `404` si l'écriture n'existe pas ou appartient à une autre company.
+ */
+export async function getJournalEntry(id: number): Promise<JournalEntryResponse> {
+	return apiClient.get<JournalEntryResponse>(`/api/v1/journal-entries/${id}`);
+}
+
 export async function createJournalEntry(
 	req: CreateJournalEntryRequest
 ): Promise<JournalEntryResponse> {

--- a/frontend/src/routes/(app)/invoices/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/invoices/[id]/+page.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { Pencil, Trash2, ArrowLeft, CheckCircle2, BookOpen, Download } from '@lucide/svelte';
+	import { Pencil, Trash2, ArrowLeft, CheckCircle2, BookOpen, Printer } from '@lucide/svelte';
 
 	import {
 		getInvoice,
@@ -308,8 +308,8 @@
 					{ number: invoice.invoiceNumber ?? '' },
 				)}
 			>
-				<Download class="h-4 w-4" aria-hidden="true" />
-				{i18nMsg('invoices-download-pdf', 'Télécharger PDF')}
+				<Printer class="h-4 w-4" aria-hidden="true" />
+				{i18nMsg('invoices-download-pdf', 'Imprimer / Télécharger PDF')}
 			</Button>
 			{#if invoice.journalEntryId}
 				<Button

--- a/frontend/src/routes/(app)/journal-entries/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/journal-entries/[id]/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { ArrowLeft } from '@lucide/svelte';
+	import Big from 'big.js';
+	import { getJournalEntry } from '$lib/features/journal-entries/journal-entries.api';
+	import type { JournalEntryResponse } from '$lib/features/journal-entries/journal-entries.types';
+	import { fetchAccounts } from '$lib/features/accounts/accounts.api';
+	import type { AccountResponse } from '$lib/features/accounts/accounts.types';
+	import { formatSwissAmount } from '$lib/features/journal-entries/balance';
+	import { isApiError } from '$lib/shared/utils/api-client';
+
+	let entry = $state<JournalEntryResponse | null>(null);
+	let accountsById = $state<Map<number, AccountResponse>>(new Map());
+	let loading = $state(true);
+	let errorMsg = $state('');
+
+	let id = $derived(parseInt(page.params.id ?? '', 10));
+
+	onMount(async () => {
+		if (!Number.isFinite(id) || id <= 0) {
+			errorMsg = "Identifiant d'écriture invalide";
+			loading = false;
+			return;
+		}
+		try {
+			// Comptes chargés en parallèle pour résoudre accountId → numéro + nom.
+			// `fetchAccounts(true)` inclut les comptes archivés : une écriture
+			// historique peut référencer un compte depuis archivé.
+			const [e, accounts] = await Promise.all([getJournalEntry(id), fetchAccounts(true)]);
+			entry = e;
+			accountsById = new Map(accounts.map((a) => [a.id, a]));
+		} catch (err) {
+			errorMsg = isApiError(err) ? err.message : "Erreur de chargement de l'écriture";
+		} finally {
+			loading = false;
+		}
+	});
+
+	function accountLabel(accountId: number): string {
+		const a = accountsById.get(accountId);
+		return a ? `${a.number} — ${a.name}` : `#${accountId}`;
+	}
+
+	/** Blanchit les montants nuls (convention comptable : débit OU crédit par ligne). */
+	function fmtAmount(v: string): string {
+		try {
+			const b = new Big(v || '0');
+			return b.eq(0) ? '' : formatSwissAmount(b);
+		} catch {
+			return v;
+		}
+	}
+
+	function sumLines(field: 'debit' | 'credit'): Big {
+		if (!entry) return new Big(0);
+		return entry.lines.reduce((acc, l) => acc.plus(new Big(l[field] || '0')), new Big(0));
+	}
+
+	let totalDebit = $derived(sumLines('debit'));
+	let totalCredit = $derived(sumLines('credit'));
+</script>
+
+<svelte:head>
+	<title>{entry ? `Écriture n°${entry.entryNumber}` : 'Écriture'} — Kesh</title>
+</svelte:head>
+
+<div class="mb-6 flex items-center justify-between">
+	<Button variant="ghost" onclick={() => goto('/journal-entries')}>
+		<ArrowLeft class="h-4 w-4" aria-hidden="true" />
+		Retour
+	</Button>
+</div>
+
+{#if loading}
+	<p class="text-sm text-text-muted">Chargement…</p>
+{:else if errorMsg}
+	<div class="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">
+		{errorMsg}
+	</div>
+{:else if entry}
+	<h1 class="mb-4 text-2xl font-semibold text-text">Écriture n°{entry.entryNumber}</h1>
+
+	<dl class="mb-6 grid grid-cols-1 gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+		<div class="flex justify-between border-b border-border py-1">
+			<dt class="text-text-muted">Date</dt>
+			<dd class="font-medium">{entry.entryDate}</dd>
+		</div>
+		<div class="flex justify-between border-b border-border py-1">
+			<dt class="text-text-muted">Journal</dt>
+			<dd class="font-medium">{entry.journal}</dd>
+		</div>
+		<div class="flex justify-between border-b border-border py-1 sm:col-span-2">
+			<dt class="text-text-muted">Libellé</dt>
+			<dd class="font-medium">{entry.description}</dd>
+		</div>
+	</dl>
+
+	<table class="w-full border-collapse text-sm">
+		<thead>
+			<tr class="border-b border-border text-left">
+				<th class="py-2 pr-2">Compte</th>
+				<th class="py-2 pr-2 w-36 text-right">Débit</th>
+				<th class="py-2 pr-2 w-36 text-right">Crédit</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each entry.lines as line (line.id)}
+				<tr class="border-b border-border">
+					<td class="py-2 pr-2">{accountLabel(line.accountId)}</td>
+					<td class="py-2 pr-2 text-right font-mono">{fmtAmount(line.debit)}</td>
+					<td class="py-2 pr-2 text-right font-mono">{fmtAmount(line.credit)}</td>
+				</tr>
+			{/each}
+		</tbody>
+		<tfoot>
+			<tr class="font-semibold">
+				<td class="py-3 text-right">Total</td>
+				<td class="py-3 pr-2 text-right font-mono">{formatSwissAmount(totalDebit)}</td>
+				<td class="py-3 pr-2 text-right font-mono">{formatSwissAmount(totalCredit)}</td>
+			</tr>
+		</tfoot>
+	</table>
+{/if}


### PR DESCRIPTION
Trois retours du dogfooding live de la facturation sur prod NAS Synology v0.1.5.

## #148 — « Voir l'écriture comptable » → 404 (bug)

Sur une facture validée, le bouton menait à `/journal-entries/{id}`, **route inexistante** → 404 SvelteKit. Confirmé par les logs NAS (aucune erreur serveur — le backend n'était jamais appelé).

- **Backend** : `GET /api/v1/journal-entries/{id}` (`get_journal_entry`, dans `authenticated_routes` comme la liste) réutilisant `journal_entries::find_by_id` (scopé société). Inexistant/cross-tenant → `404 NOT_FOUND` (anti-énumération KF-002).
- **Frontend** : page `/journal-entries/[id]/+page.svelte` (lignes débit/crédit, comptes résolus, totaux) + getter `getJournalEntry`.
- **Test** : `idor_journal_entries_cross_company_returns_404` (cross-tenant 404 + inexistant 404 + own 200 avec lignes) — ✅ PASS.

## #149 — Placement des boutons d'ajout de ligne (UX)

« Ligne libre » / « Depuis catalogue » déplacés de l'en-tête vers **sous le tableau des lignes**.

## #150 — Découvrabilité de l'impression (UX)

« Télécharger PDF » → **« Imprimer / Télécharger PDF »** + icône imprimante.

## Vérifications (Test Locally First)

- Backend : ✅ `fmt`, `build`, `clippy -D warnings`, nouveau test IDOR **PASS** (DB éphémère sqlx::test, non affectée par #140).
- Frontend : ✅ `check` (0 erreur), `lint-i18n-ownership`, `test:unit` (267), `build`.

## Hors scope (issues créées séparément)

- #151 — complétude PDF facture (coordonnées émetteur, n° client, **récap TVA → Epic 11/v0.2**).
- #152 — choix du compte de produit par ligne (3000/3200) — touche modèle facture + moteur comptable.

Closes #148
Closes #149
Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)