### PR TITLE
fix(dogfooding v0.1.6): tests fiscal_year auto-réparants (#140) + aide champ QR-IBAN (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
+## [0.1.7] — Non publié
+
+Correctifs issus du dogfooding live de la facturation sur prod NAS Synology v0.1.6.
+
+### Changed
+
+- **Compte bancaire — aide sur le champ QR-IBAN** (#155) : un texte explicatif précise désormais que le champ « QR-IBAN » ne doit être rempli **que** si la banque a fourni un QR-IBAN dédié aux QR-factures (identifiant 30000–31999), et qu'il faut sinon le laisser vide (l'IBAN normal suffit pour générer des QR-factures). En cas de saisie d'un IBAN qui n'est pas un QR-IBAN, le message d'erreur est désormais actionnable (« laissez ce champ vide ») au lieu du message technique « QR-IID … hors plage 30000-31999 ».
+
+### Fixed
+
+- **Suite de tests `journal_entries` auto-réparante** (#140) : 20 tests backend échouaient en `FiscalYearClosed` lorsque l'exercice de l'année courante était clos en base de développement (clôture manuelle pendant le dogfooding, ou test antérieur le laissant clos). Le helper de test garantit désormais un exercice **ouvert** couvrant la date du jour, indépendamment de l'état du seed. Aucun impact sur l'application ni sur les données — correctif purement test (dette technique catégorie A levée avant le passage à v0.2).
+
+---
+
 ## [0.1.6] — 2026-06-03
 
 Correctifs et améliorations issus du dogfooding live de la facturation sur prod NAS Synology v0.1.5.

--- a/crates/kesh-db/src/repositories/journal_entries.rs
+++ b/crates/kesh-db/src/repositories/journal_entries.rs
@@ -974,12 +974,9 @@ mod tests {
         // Nettoyer les écritures existantes pour éviter les interférences.
         delete_all_by_company(pool, company_id).await.unwrap();
 
-        // Récupérer l'exercice ouvert courant.
+        // Garantir un exercice OUVERT couvrant aujourd'hui (auto-réparation #140).
         let today = chrono::Utc::now().naive_utc().date();
-        let fy = fiscal_years::find_covering_date(pool, company_id, today)
-            .await
-            .expect("find_covering_date")
-            .expect("need fiscal year for today (run seed-demo)");
+        let fy = ensure_open_fiscal_year(pool, company_id, today).await;
 
         // Récupérer l'admin user pour l'audit log (dupliqué depuis
         // audit_log::tests story 3.3 — voir spec 3.5 Dev Notes L1).
@@ -990,6 +987,56 @@ mod tests {
                 .expect("need at least one admin user (run seed-demo or bootstrap)");
 
         (company_id, fy.id, admin_user_id)
+    }
+
+    /// Garantit qu'un exercice fiscal **ouvert** couvre `date` et le retourne.
+    ///
+    /// Auto-réparation #140 : la suite dépend d'un exercice ouvert couvrant le
+    /// jour J, récupéré via `find_covering_date`. Or un run précédent peut
+    /// laisser l'exercice clos (p. ex. `update_no_op_in_closed_fy_*` clôt sans
+    /// recréer), tout comme une clôture manuelle en base dev pendant le
+    /// dogfooding. Dans ces cas, `setup` récupérait un exercice `Closed` et tous
+    /// les tests suivants échouaient en `FiscalYearClosed`. On rétablit donc un
+    /// exercice ouvert : si l'exercice couvrant est clos, on le supprime (après
+    /// purge des écritures pour respecter la FK) et on en recrée un ouvert pour
+    /// l'année calendaire ; si aucun exercice ne couvre la date, on en crée un.
+    /// Même pattern delete+recreate que `test_create_rejects_closed_fiscal_year`.
+    async fn ensure_open_fiscal_year(
+        pool: &MySqlPool,
+        company_id: i64,
+        date: NaiveDate,
+    ) -> crate::entities::FiscalYear {
+        use crate::entities::FiscalYearStatus;
+
+        if let Some(fy) = fiscal_years::find_covering_date(pool, company_id, date)
+            .await
+            .expect("find_covering_date")
+        {
+            if fy.status == FiscalYearStatus::Open {
+                return fy;
+            }
+            // Exercice couvrant mais clos → purge des écritures puis suppression
+            // (un exercice clos ne peut pas être rouvert par politique métier).
+            delete_all_by_company(pool, company_id).await.unwrap();
+            sqlx::query("DELETE FROM fiscal_years WHERE id = ?")
+                .bind(fy.id)
+                .execute(pool)
+                .await
+                .expect("delete closed fiscal year");
+        }
+
+        let year = date.year();
+        fiscal_years::create_for_seed(
+            pool,
+            crate::entities::NewFiscalYear {
+                company_id,
+                name: format!("Exercice {year}"),
+                start_date: NaiveDate::from_ymd_opt(year, 1, 1).unwrap(),
+                end_date: NaiveDate::from_ymd_opt(year, 12, 31).unwrap(),
+            },
+        )
+        .await
+        .expect("create open fiscal year for tests")
     }
 
     /// Récupère 2 comptes actifs pour les tests (premier actif puis un autre).

--- a/frontend/src/routes/(app)/bank-accounts/+page.svelte
+++ b/frontend/src/routes/(app)/bank-accounts/+page.svelte
@@ -139,9 +139,37 @@
 		resetForm();
 	}
 
+	/**
+	 * #155 — un QR-IBAN valide porte une QR-IID (positions 5–9 de l'IBAN) dans
+	 * la plage 30000–31999. On valide côté client pour afficher un message
+	 * actionnable (« laissez ce champ vide ») plutôt que l'erreur backend
+	 * technique « QR-IID … hors plage … ». Cas le plus fréquent : l'utilisateur
+	 * recopie son IBAN normal (ex. BCV, IID 00767) dans ce champ optionnel.
+	 */
+	function qrIbanHasValidQrIid(value: string): boolean {
+		const normalized = value.replace(/\s+/g, '').toUpperCase();
+		if (normalized.length < 9) return false;
+		const iid = Number(normalized.slice(4, 9));
+		return Number.isInteger(iid) && iid >= 30000 && iid <= 31999;
+	}
+
+	/** Retourne false (et positionne `formError`) si le QR-IBAN saisi n'en est pas un. */
+	function validateQrIbanField(): boolean {
+		const qrIban = formQrIban.trim();
+		if (qrIban !== '' && !qrIbanHasValidQrIid(qrIban)) {
+			formError = i18nMsg(
+				'bank-accounts-error-qr-iban-not-qr',
+				"Cet IBAN n'est pas un QR-IBAN. Si votre banque ne vous a pas fourni de QR-IBAN dédié aux QR-factures, laissez ce champ vide : votre IBAN normal suffit."
+			);
+			return false;
+		}
+		return true;
+	}
+
 	async function submitCreate(e: Event) {
 		e.preventDefault();
 		formError = null;
+		if (!validateQrIbanField()) return;
 		submitting = true;
 		try {
 			const payload: NewBankAccountPayload = {
@@ -165,6 +193,7 @@
 	async function submitUpdateFull(e: Event, id: number) {
 		e.preventDefault();
 		formError = null;
+		if (!validateQrIbanField()) return;
 		submitting = true;
 		try {
 			const payload: UpdateBankAccountPayload = {
@@ -282,6 +311,7 @@
 					<div>
 						<label for="form-qr-iban" class="block text-sm font-medium text-text mb-1">{i18nMsg('bank-accounts-labels-qr-iban', 'QR-IBAN (optionnel)')}</label>
 						<Input id="form-qr-iban" bind:value={formQrIban} placeholder="CH..." data-testid="form-qr-iban" />
+						<p class="mt-1 text-xs text-text-muted" data-testid="form-qr-iban-help">{i18nMsg('bank-accounts-help-qr-iban', 'À remplir uniquement si votre banque vous a fourni un QR-IBAN dédié aux QR-factures (numéro spécial avec un identifiant 30000–31999). Sinon, laissez ce champ vide : votre IBAN normal suffit pour générer des QR-factures.')}</p>
 					</div>
 					<div>
 						<label for="form-journal-account" class="block text-sm font-medium text-text mb-1">{i18nMsg('bank-accounts-labels-journal-account-id', 'Compte comptable lié')}</label>
@@ -432,6 +462,7 @@
 											<div>
 												<label for="edit-qr-iban" class="block text-sm font-medium text-text mb-1">{i18nMsg('bank-accounts-labels-qr-iban', 'QR-IBAN (optionnel)')}</label>
 												<Input id="edit-qr-iban" bind:value={formQrIban} data-testid="edit-qr-iban" />
+												<p class="mt-1 text-xs text-text-muted" data-testid="edit-qr-iban-help">{i18nMsg('bank-accounts-help-qr-iban', 'À remplir uniquement si votre banque vous a fourni un QR-IBAN dédié aux QR-factures (numéro spécial avec un identifiant 30000–31999). Sinon, laissez ce champ vide : votre IBAN normal suffit pour générer des QR-factures.')}</p>
 											</div>
 											<div>
 												<label for="edit-journal-account" class="block text-sm font-medium text-text mb-1">{i18nMsg('bank-accounts-labels-journal-account-id', 'Compte comptable lié')}</label>


### PR DESCRIPTION
Deux correctifs dogfooding/dette regroupés pour la release v0.1.7.

## #140 — 20 tests `journal_entries` cassés en `FiscalYearClosed` (dette catégorie A)

Le helper de test `setup()` récupérait l'exercice couvrant le jour J via `find_covering_date` et le propageait tel quel. Si cet exercice était **clos** — clôture manuelle en base dev pendant le dogfooding, ou test antérieur (`update_no_op_in_closed_fy_*`) qui clôt sans recréer — les 20 tests suivants échouaient en `FiscalYearClosed`.

**Ground-truth de la cause** : la base dev locale avait `Exercice 2026` (2026-01-01..2026-12-31) en statut `Closed`. La CI ne reproduisait pas (son seed crée un exercice Open 2020-2030), d'où des CI vertes malgré le bug local.

> Note : l'issue #140 listait aussi des tests `accounts`/`products` — vérifié faux (29 passed). `update_partial_change_bumps_version` est dans `journal_entries`, pas `accounts`. Les **20 échecs sont tous dans `journal_entries`**.

**Fix** : nouveau helper `ensure_open_fiscal_year` — si l'exercice couvrant est clos, purge des écritures (FK) + suppression + recréation d'un exercice ouvert ; si aucun ne couvre la date, création. Même pattern delete+recreate que `test_create_rejects_closed_fiscal_year`. La suite devient **auto-réparante**, indépendante de l'état du seed. Correctif purement test, aucun impact application/données.

## #155 — Aide + erreur actionnable sur le champ QR-IBAN

Le champ « QR-IBAN (optionnel) » n'avait aucune explication. Un utilisateur dont la banque ne fournit qu'un IBAN classique (ex. BCV, IID 00767) y recopiait son IBAN → message technique « QR-IID 767 hors plage 30000-31999 ».

- **Texte d'aide** sous les deux champs (création + édition) : à remplir uniquement si la banque a fourni un QR-IBAN dédié (IID 30000-31999), sinon laisser vide (l'IBAN normal suffit pour les QR-factures).
- **Validation client-side** (`qrIbanHasValidQrIid` / `validateQrIbanField`) : message actionnable affiché avant l'appel backend, indépendant du texte technique backend.

Issue liée laissée en backlog : #156 (auto-documentation par champ, candidate v0.2).

## Vérifications (Test Locally First)

- Backend : ✅ `fmt`, `clippy -D warnings`, `cargo test --workspace -j1 --test-threads=1` (DB fraîche seedée comme la CI) — **0 échec**. + 172/172 `kesh-db` sur clone de la base dev reproduisant le bug (idempotent).
- Frontend : ✅ `check` (0 erreur), `lint-i18n-ownership` (PASS), `test:unit` (267), `build`.

Closes #140
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)