### PR TITLE
fix(frontend): version affichée depuis le backend au runtime (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
+## [0.1.8] — Non publié
+
+Correctif issu du dogfooding live sur prod NAS Synology v0.1.7.
+
+### Fixed
+
+- **Numéro de version affiché incorrect** (#159) : le pied de page (ainsi que les écrans de connexion et de configuration) affichaient « Kesh v0.1.0 » au lieu de la version réellement installée. La version affichée provient désormais du **backend au runtime** (champ `version` de la réponse `/health`, résolu depuis `crates/kesh-api/Cargo.toml` à la compilation), garantissant qu'elle correspond toujours au binaire qui tourne — sans dépendre d'un fichier frontend à mettre à jour manuellement à chaque release. Cause : pieds de page codant la version en dur + source frontend (`package.json`) jamais bumpée.
+
+---
+
 ## [0.1.7] — 2026-06-03
 
 Correctifs issus du dogfooding live de la facturation sur prod NAS Synology v0.1.6.

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -8,10 +8,6 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
-	// Story 10.3 : version Kesh injectée au build par Vite `define`
-	// (cf. vite.config.ts). Lue depuis `package.json:version` via
-	// `process.env.npm_package_version`, fallback `'dev'`.
-	const __APP_VERSION__: string;
 }
 
 export {};

--- a/frontend/src/lib/shared/utils/api-health.svelte.ts
+++ b/frontend/src/lib/shared/utils/api-health.svelte.ts
@@ -13,6 +13,8 @@
  * fixe `ssr = false` + `prerender = false`), donc `setInterval` est safe.
  */
 
+import { appVersion } from '$lib/shared/utils/app-version.svelte';
+
 let _isDegraded = $state<boolean>(false);
 let _pollTimer: ReturnType<typeof setInterval> | null = null;
 // Pass 3 H2 : epoch counter pour invalider les callbacks `pollHealth` en
@@ -54,7 +56,10 @@ async function pollHealth(capturedEpoch: number): Promise<void> {
 	try {
 		const res = await fetch('/health', { signal: AbortSignal.timeout(2000) });
 		if (!res.ok) return;
-		const body = (await res.json()) as { db?: unknown };
+		const body = (await res.json()) as { db?: unknown; version?: unknown };
+		// #159 : capter la version du binaire backend depuis le même ping
+		// `/health` (DRY — pas d'endpoint ni de fetch dédié).
+		appVersion.set(body.version);
 		if (body.db !== true) return;
 		// Stale check Pass 3 H2 : si l'epoch courant diffère de celui capturé
 		// au scheduling, c'est qu'un cycle clearDegraded→setDegraded s'est

--- a/frontend/src/lib/shared/utils/app-version.svelte.ts
+++ b/frontend/src/lib/shared/utils/app-version.svelte.ts
@@ -1,0 +1,31 @@
+/**
+ * Store de la version applicative (Svelte 5 runes) — #159.
+ *
+ * La version provient du **backend au runtime** : champ `version` de la réponse
+ * `GET /health`, résolu côté Rust via `env!("CARGO_PKG_VERSION")` (donc figé à
+ * la compilation du binaire `kesh-api`, source unique = `crates/kesh-api/Cargo.toml`
+ * bumpé par `scripts/prepare-release.sh`). Sourcer depuis le backend garantit
+ * que le numéro affiché correspond toujours au binaire qui tourne, sans dépendre
+ * d'un `frontend/package.json` à bumper manuellement à chaque release.
+ *
+ * Peuplé au boot par le ping `/health` du root layout (`+layout.svelte`), et
+ * par les pings de recovery `pollHealth` (`api-health.svelte.ts`). Affiché dans
+ * les pieds de page (app + onboarding) et sur login/setup. Fallback `'—'` tant
+ * que la réponse backend n'est pas arrivée.
+ */
+
+let _version = $state<string>('—');
+
+export const appVersion = {
+	/** Version courante (`'—'` avant la 1ère réponse `/health`). */
+	get value(): string {
+		return _version;
+	},
+
+	/** Mémorise la version renvoyée par le backend. No-op si vide/non-string. */
+	set(version: unknown): void {
+		if (typeof version === 'string' && version.length > 0) {
+			_version = version;
+		}
+	}
+};

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -11,6 +11,7 @@
 	import { Search, LogOut, User, Settings, ChevronDown } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import { i18nMsg } from '$lib/shared/utils/i18n.svelte';
+	import { appVersion } from '$lib/shared/utils/app-version.svelte';
 	import { page } from '$app/state';
 
 	type NavItem =
@@ -327,7 +328,7 @@
 
 	<!-- Footer discret -->
 	<footer class="border-t border-border px-4 py-2 text-center text-xs text-text-muted">
-		Kesh v0.1.0 &mdash; Logiciel libre (EUPL 1.2). Les données ne remplacent pas un fiduciaire.
+		Kesh v{appVersion.value} &mdash; Logiciel libre (EUPL 1.2). Les données ne remplacent pas un fiduciaire.
 		{#if modeState.value === 'expert'}
 			<span class="ml-4">{i18nMsg('shortcut-new-entry', 'Ctrl+N : Nouvelle écriture')}</span>
 		{/if}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import { modeState } from '$lib/app/stores/mode.svelte';
 	import DegradedBanner from '$lib/shared/components/DegradedBanner.svelte';
 	import { apiHealth } from '$lib/shared/utils/api-health.svelte';
+	import { appVersion } from '$lib/shared/utils/app-version.svelte';
 	import { authState } from '$lib/app/stores/auth.svelte';
 	import { loadI18nMessages } from '$lib/shared/utils/i18n.svelte';
 	import { Toaster } from 'svelte-sonner';
@@ -52,12 +53,12 @@
 
 		try {
 			const res = await fetch('/health', { signal: AbortSignal.timeout(2000) });
-			if (!res.ok) {
-				apiHealth.setDegraded();
-				return;
-			}
-			const body = (await res.json()) as { db?: unknown };
-			if (body.db !== true) {
+			// #159 : `/health` renvoie aussi `version` (même en 503 DB-down) — on la
+			// capte avant le check d'état pour que le footer/login affiche la version
+			// du binaire backend qui tourne, y compris quand la DB est inaccessible.
+			const body = (await res.json().catch(() => ({}))) as { db?: unknown; version?: unknown };
+			appVersion.set(body.version);
+			if (!res.ok || body.db !== true) {
 				apiHealth.setDegraded();
 			}
 		} catch {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -5,6 +5,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { authState } from '$lib/app/stores/auth.svelte';
 	import { apiClient, isApiError } from '$lib/shared/utils/api-client';
+	import { appVersion } from '$lib/shared/utils/app-version.svelte';
 	import { AlertTriangle, Clock, WifiOff, XCircle } from '@lucide/svelte';
 
 	let username = $state('');
@@ -162,6 +163,6 @@
 		class="absolute bottom-4 left-0 right-0 text-center text-xs text-muted-foreground"
 		data-testid="app-version"
 	>
-		Kesh v{__APP_VERSION__}
+		Kesh v{appVersion.value}
 	</footer>
 </main>

--- a/frontend/src/routes/onboarding/+layout.svelte
+++ b/frontend/src/routes/onboarding/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onboardingState, i18nMsg } from '$lib/features/onboarding/onboarding.svelte';
+	import { appVersion } from '$lib/shared/utils/app-version.svelte';
 
 	let { children } = $props();
 </script>
@@ -32,6 +33,6 @@
 
 	<!-- Footer disclaimer FR7 -->
 	<footer class="mt-8 text-center text-xs text-text-muted">
-		Kesh v0.1.0 &mdash; Logiciel libre (EUPL 1.2). Les donn&eacute;es ne remplacent pas un fiduciaire.
+		Kesh v{appVersion.value} &mdash; Logiciel libre (EUPL 1.2). Les donn&eacute;es ne remplacent pas un fiduciaire.
 	</footer>
 </div>

--- a/frontend/src/routes/setup/+page.svelte
+++ b/frontend/src/routes/setup/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SetupForm from '$lib/features/setup/SetupForm.svelte';
+	import { appVersion } from '$lib/shared/utils/app-version.svelte';
 </script>
 
 <svelte:head>
@@ -13,6 +14,6 @@
 		class="absolute bottom-4 left-0 right-0 text-center text-xs text-muted-foreground"
 		data-testid="app-version"
 	>
-		Kesh v{__APP_VERSION__}
+		Kesh v{appVersion.value}
 	</footer>
 </main>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -43,14 +43,11 @@ const apiProxy = {
 // server-side par défaut).
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit(), svelteTesting()],
-	// Story 10.3 : injecte la version Kesh depuis `package.json` au build pour
-	// l'afficher en pied de la page de login (preuve que le frontend est servi
-	// correctement même DB down). Fallback `'dev'` pour les build hors-npm
-	// (npx vite build sans cycle npm) — sans fallback, `__APP_VERSION__`
-	// vaudrait le mot-clé JS `undefined` → render `Kesh vundefined`.
-	define: {
-		__APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? 'dev')
-	},
+	// #159 : la version affichée provient désormais du backend au runtime
+	// (champ `version` de `GET /health` → store `app-version.svelte.ts`), source
+	// unique = `crates/kesh-api/Cargo.toml` via `env!("CARGO_PKG_VERSION")`. Plus
+	// de `__APP_VERSION__` build-time depuis `package.json` (qui dérivait, figé à
+	// 0.1.0). Cf. `app-version.svelte.ts`.
 	server: {
 		proxy: apiProxy
 	},


### PR DESCRIPTION
Correctif dogfooding (v0.1.7 NAS) : le pied de page affichait « Kesh v0.1.0 » au lieu de la version installée.

## Cause (deux bugs)

1. **Footers codés en dur** : `(app)/+layout.svelte` et `onboarding/+layout.svelte` contenaient la chaîne littérale `Kesh v0.1.0`.
2. **`__APP_VERSION__` figé** : sur login/setup, la version venait de `frontend/package.json` (= `0.1.0`, jamais bumpé par `prepare-release.sh`) injecté au build par Vite.

## Fix (DRY, source unique = Cargo.toml, runtime backend→frontend)

La version provient désormais du **backend au runtime** via le champ `version` **déjà présent** dans la réponse `GET /health` (résolu côté Rust par `env!("CARGO_PKG_VERSION")` → source unique `crates/kesh-api/Cargo.toml`, bumpé par le script de release). **Aucun endpoint ni fetch ajouté** : on réutilise le ping `/health` déjà émis au boot (`+layout`) et en recovery (`pollHealth`) — application du principe DRY.

- Nouveau store `app-version.svelte.ts` (`appVersion.value`, fallback `'—'`).
- `+layout` onMount : capte `version` du body `/health`, **y compris en 503** (DB down) → la version reste affichée sur login même DB inaccessible (intention Story 10.3 préservée).
- 4 points d'affichage (footers app/onboarding + login + setup) câblés sur `appVersion.value`.
- Suppression du code mort `__APP_VERSION__` (`define` vite + `app.d.ts`).

## Vérifications

- Frontend : ✅ `check` (0 erreur), `lint-i18n-ownership` (PASS), `test:unit` (267), `build`.
- E2E `db-resilience.spec.ts` : non relancé localement (backend test-mode requis ; non exécuté par la CI — cohérent hotfix #153/#157). Son assertion (`/health` mocké avec `version` → footer matche `/v\d+\.\d+\.\d+/`) est satisfaite par construction : le code capte `version` du body même en 503.
- Backend : **aucun changement Rust** (réutilise `/health` existant).

Nécessite release v0.1.8 (l'image 0.1.7 affiche encore 0.1.0).

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)