### PR TITLE
chore(release): préparation v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
-## [0.2.0] — Non publié
+## [0.2.0] — 2026-06-12
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Le contenu est rédigé en français à destination des **fiduciaires, PME, ind�
 
 ---
 
-## [Non publié]
+## [0.2.0] — Non publié
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-api"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "axum",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "kesh-import",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-db"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dotenvy",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-i18n"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "fluent-bundle",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-import"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2059,11 +2059,11 @@ dependencies = [
 
 [[package]]
 name = "kesh-payment"
-version = "0.1.8"
+version = "0.2.0"
 
 [[package]]
 name = "kesh-qrbill"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "printpdf",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-reconciliation"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "kesh-db",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-report"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "kesh-seed"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Le projet suit une approche **BMAD** (Breakthrough Method of Agile AI-driven Dev
 | v0.1.6 (hotfix) | Page détail d'une écriture comptable (`/journal-entries/{id}`) + fix bouton 404 « Voir l'écriture comptable » + UX facture (placement boutons ajout de ligne, libellé bouton impression) | ✅ Done |
 | v0.1.7 (hotfix) | Aide + message d'erreur actionnable sur le champ QR-IBAN (compte bancaire) + fiabilisation de la suite de tests `fiscal_year` (dette technique) | ✅ Done |
 | v0.1.8 (hotfix) | Numéro de version affiché corrigé : provient désormais du backend au runtime (champ `version` de `/health`) au lieu d'être codé en dur dans le frontend | ✅ Done |
-| v0.2 | **E17 Infra & Souveraineté** (API PAT, export/import installation, recovery mot de passe, fix sécurité — *démarre v0.2*), E11 TVA Suisse, **E16 Facturation avancée** (compte produit par ligne, PDF complet), E12 Avoirs & Paiements (pain.001), E13 Budgets, E14 Clôture d'exercice, E15 Justificatifs, Lettrage & Compléments (inc. journaux personnalisables) | 🚧 En cours |
+| v0.2.0 | **E17 Infra & Souveraineté** — API externe PAT, export/import complet d'installation (`.keshbackup`), récupération de mot de passe par email, fix sécurité TOCTOU onboarding | ✅ Done |
+| v0.2 (suite) | E11 TVA Suisse, **E16 Facturation avancée** (compte produit par ligne, PDF complet), E12 Avoirs & Paiements (pain.001), E13 Budgets, E14 Clôture d'exercice, E15 Justificatifs, Lettrage & Compléments (inc. journaux personnalisables) | 🚧 En cours |
 
 Détails : [PRD complet](_bmad-output/planning-artifacts/prd.md).
 

--- a/crates/kesh-api/Cargo.toml
+++ b/crates/kesh-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-api"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-core/Cargo.toml
+++ b/crates/kesh-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-core"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-db/Cargo.toml
+++ b/crates/kesh-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-db"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-i18n/Cargo.toml
+++ b/crates/kesh-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-i18n"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-import/Cargo.toml
+++ b/crates/kesh-import/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-import"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Parseurs CAMT.053 ISO 20022 et CSV multi-encodage pour relevés bancaires"

--- a/crates/kesh-payment/Cargo.toml
+++ b/crates/kesh-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-payment"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-qrbill/Cargo.toml
+++ b/crates/kesh-qrbill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-qrbill"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Swiss QR Bill SIX 2.2 payload builder and PDF generator (standalone, publishable)"

--- a/crates/kesh-reconciliation/Cargo.toml
+++ b/crates/kesh-reconciliation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-reconciliation"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-report/Cargo.toml
+++ b/crates/kesh-report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-report"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kesh-seed/Cargo.toml
+++ b/crates/kesh-seed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kesh-seed"
-version = "0.1.8"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/website/index.html
+++ b/website/index.html
@@ -67,7 +67,7 @@
 			<div class="max-w-4xl mx-auto text-center">
 				<div class="animate-fade-up inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-300 text-sm font-medium mb-6">
 					<span class="w-2 h-2 rounded-full bg-emerald-400"></span>
-					v0.1.0 released — Docker image available
+					v0.2.0 released — Docker image available
 				</div>
 				<h1 class="animate-fade-up delay-1 text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight mb-6">
 					Open-source <span class="bg-gradient-to-r from-emerald-400 via-blue-400 to-emerald-500 bg-clip-text text-transparent">Swiss accounting</span> &amp; invoicing

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -223,6 +223,13 @@
 			<p class="text-slate-400 mb-10">Everything an SME needs to run a full fiscal year on Kesh: VAT computation, outgoing payments, budgets, year-end closing.</p>
 
 			<div class="grid sm:grid-cols-2 gap-4">
+				<div class="p-5 rounded-xl bg-slate-900 border border-emerald-500/30 sm:col-span-2">
+					<div class="flex items-center justify-between mb-1 flex-wrap gap-2">
+						<h3 class="font-semibold">E17 — Infrastructure &amp; Sovereignty <span class="text-slate-500 font-mono text-xs">v0.2.0</span></h3>
+						<span class="text-xs font-mono px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">Done</span>
+					</div>
+					<p class="text-sm text-slate-400">External API with personal access tokens (read / read-write, per company), full installation export/import (<code>.keshbackup</code>) for SSH-free migration and restore, self-service password recovery by email (anti-enumeration, single-use 30-min links), atomic first-admin setup (TOCTOU fix).</p>
+				</div>
 				<div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
 					<h3 class="font-semibold mb-1">E11 — Swiss VAT</h3>
 					<p class="text-sm text-slate-400">Per-period VAT computation, official VAT report formats, multiple rates (standard, reduced, accommodation).</p>


### PR DESCRIPTION
## Préparation de la release v0.2.0

Branche de release post-rétro Epic 17 (#176). Contenu :

- **Bump de version** : 10 crates `0.1.8` → `0.2.0` + `Cargo.lock` (via `scripts/prepare-release.sh`)
- **CHANGELOG.md** : section `[Non publié]` → `[0.2.0]` datée 2026-06-12 (API PAT #100, recovery email #122, export/import installation #112)
- **README** Feuille de route : v0.2.0 (Epic 17) ✅ Done, suite v0.2 🚧
- **Website** : badge hero v0.2.0 + carte Epic 17 Done dans roadmap (action item #4 rétro Epic 17)

### Checks locaux (Test Locally First)

- `cargo fmt --check` ✅
- `cargo build --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test` workspace ✅ (kesh-db 187/187 en serial, collisions parallèles connues)
- Frontend : `check` + `lint-i18n-ownership` + `test:unit` 312/312 + `build` ✅

Après merge : tag `v0.2.0` + release Docker Hub (gate Guy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)